### PR TITLE
Added 'x-api-key' to CORS_ALLOW_HEADERS

### DIFF
--- a/pantau_tular/settings.py
+++ b/pantau_tular/settings.py
@@ -165,6 +165,7 @@ CORS_ALLOW_HEADERS = [
     'user-agent',
     'x-csrftoken',
     'x-requested-with',
+    'x-api-key',
 ]
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'


### PR DESCRIPTION
# Overview
This a minor update to the settings.py to allow the frontend to flawlessly fetch data.

# Changes
## Updated CORS_ALLOW_HEADERS
- Added 'x-api-key' to CORS_ALLOW_HEADERS