### PR TITLE
[PBI D01] get gender distribution

### DIFF
--- a/pt_backend/repositories.py
+++ b/pt_backend/repositories.py
@@ -37,3 +37,9 @@ class NewsRepository:
 class CaseRepository(CaseRepositoryInterface):
     def get_all_locations(self):
         return Case.get_all_locations()
+    
+    def get_gender_distribution(self):
+        return {
+            'male': Case.objects.filter(gender__iexact='male').count(),
+            'female': Case.objects.filter(gender__iexact='female').count()
+        }

--- a/pt_backend/repositories.py
+++ b/pt_backend/repositories.py
@@ -1,5 +1,6 @@
 from .models import Case, Disease, Location, News
 from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import Count, Case
 from .models import Case
 from .interfaces import CaseRepositoryInterface
 
@@ -39,7 +40,11 @@ class CaseRepository(CaseRepositoryInterface):
         return Case.get_all_locations()
     
     def get_gender_distribution(self):
-        return {
-            'male': Case.objects.filter(gender__iexact='male').count(),
-            'female': Case.objects.filter(gender__iexact='female').count()
-        }
+        gender_counts = Case.objects.values('gender').annotate(count=Count('id'))
+        distribution = {'male': 0, 'female': 0}
+        for gender_count in gender_counts:
+            if gender_count['gender'].lower() == 'male':
+                distribution['male'] = gender_count['count']
+            elif gender_count['gender'].lower() == 'female':
+                distribution['female'] = gender_count['count']
+        return distribution

--- a/pt_backend/serializers.py
+++ b/pt_backend/serializers.py
@@ -7,5 +7,5 @@ class CaseLocationSerializer(serializers.Serializer):
     city = serializers.CharField(max_length=255)
 
 class GenderDistributionSerializer(serializers.Serializer):
-    male = serializers.CharField(max_length=10)
-    female = serializers.CharField(max_length=10)
+    male = serializers.IntegerField()
+    female = serializers.IntegerField()

--- a/pt_backend/serializers.py
+++ b/pt_backend/serializers.py
@@ -6,3 +6,6 @@ class CaseLocationSerializer(serializers.Serializer):
     location__latitude = serializers.DecimalField(max_digits=8, decimal_places=6)
     city = serializers.CharField(max_length=255)
 
+class GenderDistributionSerializer(serializers.Serializer):
+    male = serializers.CharField(max_length=10)
+    female = serializers.CharField(max_length=10)

--- a/pt_backend/services.py
+++ b/pt_backend/services.py
@@ -15,7 +15,9 @@ class CaseService(CaseRetrievalInterface):
             locations = self.repository.get_all_locations()
             self.cache_service.set(self.CACHE_KEY, locations, timeout=self.CACHE_TIMEOUT)
         return locations if locations else []
-
+    
+    def get_gender_dist(self):
+        return self.repository.get_gender_distribution()
 
 class CacheService(CacheInterface):
     def get(self, key):

--- a/pt_backend/tests/test_repository.py
+++ b/pt_backend/tests/test_repository.py
@@ -113,6 +113,25 @@ class CaseRepositoryTestCase(TestCase):
             disease=self.disease,
             location=self.location
         )
+        self.case2 = Case.objects.create(
+            id=uuid.uuid4(),
+            gender="Male",
+            age=25,
+            city="Bandung",
+            status="recovered",
+            disease=self.disease,
+            location=self.location
+        )
+        self.case3 = Case.objects.create(
+            id=uuid.uuid4(),
+            gender="Male",
+            age=25,
+            city="Bandung",
+            status="recovered",
+            disease=self.disease,
+            location=self.location
+        )
+
         self.repository = CaseRepository()
 
     def test_get_all_case_locations(self):
@@ -129,32 +148,12 @@ class CaseRepositoryTestCase(TestCase):
         Case.objects.all().delete()
         locations = self.repository.get_all_locations()
         self.assertFalse(locations.exists())
-
-class GenderRepositoryTest(TestCase):
-    def setUp(self):
-        self.disease = Disease.objects.create(name="COVID-19", level_of_alertness=5)
-        self.location = Location.objects.create(
-            latitude=-6.9175, longitude=107.6191, name="Bandung"
-        )
-        # Menambahkan beberapa data kasus untuk menguji
-        Case.objects.create(gender='Male', age=30, city='CityA', status='biasa', severity='insiden', disease=self.disease, location=self.location)
-        Case.objects.create(gender='Female', age=25, city='CityB', status='minimal', severity='mortalitas', disease=self.disease, location=self.location)
-        Case.objects.create(gender='Male', age=40, city='CityC', status='bahaya', severity='hospitalisasi', disease=self.disease, location=self.location)
     
-    def test_get_gender_distribution_positive(self):
-        # Tes distribusi gender yang benar
-        repository = GenderRepository()
-        result = repository.get_gender_distribution()
-
-        self.assertEqual(result['Male'], 2)  # Harus ada 2 kasus laki-laki
-        self.assertEqual(result['Female'], 1)  # Harus ada 1 kasus perempuan
-
+    def test_get_gender_distribution(self):
+        result = self.repository.get_gender_distribution()
+        self.assertEqual(result, {'male': 2, 'female': 1})
+    
     def test_get_gender_distribution_empty(self):
-        # Menghapus semua data dan memastikan distribusi gender adalah 0
         Case.objects.all().delete()
-        
-        repository = GenderRepository()
-        result = repository.get_gender_distribution()
-
-        self.assertEqual(result['Male'], 0)
-        self.assertEqual(result['Female'], 0)
+        result = self.repository.get_gender_distribution()
+        self.assertEqual(result, {'male': 0, 'female': 0})

--- a/pt_backend/tests/test_repository.py
+++ b/pt_backend/tests/test_repository.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from django.test import TestCase
 from pt_backend.models import Case, Disease, Location, News
-from pt_backend.repositories import DiseaseRepository, LocationRepository, NewsRepository, CaseRepository
+from pt_backend.repositories import DiseaseRepository, LocationRepository, NewsRepository, CaseRepository, GenderRepository
 from django.core.exceptions import ObjectDoesNotExist
 import uuid
 from unittest.mock import patch
@@ -129,3 +129,32 @@ class CaseRepositoryTestCase(TestCase):
         Case.objects.all().delete()
         locations = self.repository.get_all_locations()
         self.assertFalse(locations.exists())
+
+class GenderRepositoryTest(TestCase):
+    def setUp(self):
+        self.disease = Disease.objects.create(name="COVID-19", level_of_alertness=5)
+        self.location = Location.objects.create(
+            latitude=-6.9175, longitude=107.6191, name="Bandung"
+        )
+        # Menambahkan beberapa data kasus untuk menguji
+        Case.objects.create(gender='Male', age=30, city='CityA', status='biasa', severity='insiden', disease=self.disease, location=self.location)
+        Case.objects.create(gender='Female', age=25, city='CityB', status='minimal', severity='mortalitas', disease=self.disease, location=self.location)
+        Case.objects.create(gender='Male', age=40, city='CityC', status='bahaya', severity='hospitalisasi', disease=self.disease, location=self.location)
+    
+    def test_get_gender_distribution_positive(self):
+        # Tes distribusi gender yang benar
+        repository = GenderRepository()
+        result = repository.get_gender_distribution()
+
+        self.assertEqual(result['Male'], 2)  # Harus ada 2 kasus laki-laki
+        self.assertEqual(result['Female'], 1)  # Harus ada 1 kasus perempuan
+
+    def test_get_gender_distribution_empty(self):
+        # Menghapus semua data dan memastikan distribusi gender adalah 0
+        Case.objects.all().delete()
+        
+        repository = GenderRepository()
+        result = repository.get_gender_distribution()
+
+        self.assertEqual(result['Male'], 0)
+        self.assertEqual(result['Female'], 0)

--- a/pt_backend/tests/test_repository.py
+++ b/pt_backend/tests/test_repository.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from django.test import TestCase
 from pt_backend.models import Case, Disease, Location, News
-from pt_backend.repositories import DiseaseRepository, LocationRepository, NewsRepository, CaseRepository, GenderRepository
+from pt_backend.repositories import DiseaseRepository, LocationRepository, NewsRepository, CaseRepository
 from django.core.exceptions import ObjectDoesNotExist
 import uuid
 from unittest.mock import patch
@@ -137,7 +137,7 @@ class CaseRepositoryTestCase(TestCase):
     def test_get_all_case_locations(self):
         locations = self.repository.get_all_locations()
         self.assertTrue(locations.exists())
-        self.assertEqual(locations.count(), 1)
+        self.assertEqual(locations.count(), 3)
         case_data = locations.first()
         self.assertEqual(str(case_data["id"]), str(self.case.id))
         self.assertEqual(float(case_data["location__latitude"]), -6.9175)

--- a/pt_backend/tests/test_views.py
+++ b/pt_backend/tests/test_views.py
@@ -143,9 +143,9 @@ class GenderDistAPITest(TestCase):
         self.location = Location.objects.create(
             latitude=-6.9175, longitude=107.6191, name="Bandung"
         )
-        Case.objects.create(gender='Male', age=30, city='CityA', status='biasa', severity='insiden', disease=self.disease, location=self.location)
-        Case.objects.create(gender='Female', age=25, city='CityB', status='minimal', severity='mortalitas', disease=self.disease, location=self.location)
-        Case.objects.create(gender='Male', age=40, city='CityC', status='bahaya', severity='hospitalisasi', disease=self.disease, location=self.location)
+        Case.objects.create(gender='male', age=30, city='CityA', status='biasa', severity='insiden', disease=self.disease, location=self.location)
+        Case.objects.create(gender='female', age=25, city='CityB', status='minimal', severity='mortalitas', disease=self.disease, location=self.location)
+        Case.objects.create(gender='male', age=40, city='CityC', status='bahaya', severity='hospitalisasi', disease=self.disease, location=self.location)
     
     def test_get_gender_dist(self):
         response = self.client.get('/api/gender-distribution/')

--- a/pt_backend/tests/test_views.py
+++ b/pt_backend/tests/test_views.py
@@ -151,7 +151,7 @@ class GenderDistAPITest(TestCase):
         response = self.client.get('/api/gender-distribution/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         expected_data = {
-            'Male': 2, 'Female': 1
+            'male': 2, 'female': 1
         }
         self.assertEqual(response.data, expected_data)
     
@@ -160,8 +160,8 @@ class GenderDistAPITest(TestCase):
         response = self.client.get('/api/gender-distribution/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         expected_data = {
-            'Male': 0,
-            'Female': 0
+            'male': 0,
+            'female': 0
         }
         self.assertEqual(response.data, expected_data)
 

--- a/pt_backend/tests/test_views.py
+++ b/pt_backend/tests/test_views.py
@@ -153,13 +153,9 @@ class GenderDistAPITest(TestCase):
         Case.objects.create(gender='male', age=40, city='CityC', status='bahaya', severity='hospitalisasi', disease=self.disease, location=self.location)
 
     def test_get_gender_dist(self):
-        gender_dist = self.service.get_gender_dist()
-        expected_res = {
-            'male': 2,
-            'female': 1
-        }
-
-        self.assertEqual(expected_res, gender_dist)
+        response = self.client.get('/api/cases/gender-distribution/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {'male': 2, 'female': 1})
     
     @patch('pt_backend.services.CaseService.get_gender_dist')
     def test_get_gender_dist_exception(self, mock_get_gender_dist):

--- a/pt_backend/tests/test_views.py
+++ b/pt_backend/tests/test_views.py
@@ -132,3 +132,43 @@ class CaseFilterPostTest(TestCase):
         response = self.client.post('/cases/locations/', {}, format='json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.json(), {"detail": "Invalid API Key"})
+
+class GenderDistAPITest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.api_key = os.getenv("SECRET_API_KEY", "test-api-key")
+        self.client.credentials(HTTP_X_API_KEY=self.api_key)
+
+        self.disease = Disease.objects.create(name="COVID-19", level_of_alertness=5)
+        self.location = Location.objects.create(
+            latitude=-6.9175, longitude=107.6191, name="Bandung"
+        )
+        Case.objects.create(gender='Male', age=30, city='CityA', status='biasa', severity='insiden', disease=self.disease, location=self.location)
+        Case.objects.create(gender='Female', age=25, city='CityB', status='minimal', severity='mortalitas', disease=self.disease, location=self.location)
+        Case.objects.create(gender='Male', age=40, city='CityC', status='bahaya', severity='hospitalisasi', disease=self.disease, location=self.location)
+    
+    def test_get_gender_dist(self):
+        response = self.client.get('/api/gender-distribution/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_data = {
+            'Male': 2, 'Female': 1
+        }
+        self.assertEqual(response.data, expected_data)
+    
+    def test_get_gender_dist_empty(self):
+        Case.objects.all().delete()
+        response = self.client.get('/api/gender-distribution/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_data = {
+            'Male': 0,
+            'Female': 0
+        }
+        self.assertEqual(response.data, expected_data)
+
+    @patch('pt_backend.services.GenderDistributionService.get_gender_distribution')
+    def test_get_gender_dist_exception(self, mock_get_gender_dist):
+        mock_get_gender_dist.side_effect = Exception("Database error")
+
+        response = self.client.get('/api/gender-distribution/')
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.json(), {"error": "An unexpected error occurred. Please try again later."})

--- a/pt_backend/tests/test_views.py
+++ b/pt_backend/tests/test_views.py
@@ -155,13 +155,13 @@ class GenderDistAPITest(TestCase):
     def test_get_gender_dist(self):
         response = self.client.get('/api/cases/gender-distribution/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), {'male': 2, 'female': 1})
+        self.assertEqual(response.json(), {'gender_distribution': {'male': 2, 'female': 1}})
     
     def test_get_gender_dist_if_invalid_gender(self):
         Case.objects.create(gender='BLABLA', age=30, city='CityA', status='biasa', severity='insiden', disease=self.disease, location=self.location)
         response = self.client.get('/api/cases/gender-distribution/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), {'male':2, 'female':1}) #buat cek klo ada yg ga valid masi return gender yg valid atau nggak
+        self.assertEqual(response.json(), {'gender_distribution': {'male': 2, 'female': 1}}) #buat cek klo ada yg ga valid masi return gender yg valid atau nggak
 
     @patch('pt_backend.services.CaseService.get_gender_dist')
     def test_get_gender_dist_exception(self, mock_get_gender_dist):
@@ -172,9 +172,11 @@ class GenderDistAPITest(TestCase):
 
         response = self.client.get('/api/cases/gender-distribution/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, {
-            'male': 2,
-            'female': 1
+        self.assertEqual(response.json(), {
+            'gender_distribution': {
+                'male': 2,
+                'female': 1
+            }
         })
 
     @patch('pt_backend.services.CaseService.get_gender_dist')

--- a/pt_backend/tests/test_views.py
+++ b/pt_backend/tests/test_views.py
@@ -2,7 +2,8 @@ from django.test import TestCase
 from rest_framework.test import APIClient
 from rest_framework import status
 from pt_backend.models import Case, Location, Disease
-from pt_backend.services import CacheService
+from pt_backend.services import CacheService, CaseService
+from pt_backend.repositories import CaseRepository
 import uuid
 import os
 from unittest.mock import patch, Mock
@@ -139,6 +140,10 @@ class GenderDistAPITest(TestCase):
         self.api_key = os.getenv("SECRET_API_KEY", "test-api-key")
         self.client.credentials(HTTP_X_API_KEY=self.api_key)
 
+        self.cache_service = CacheService()
+        self.repository = CaseRepository()
+        self.service = CaseService(self.repository, self.cache_service)
+
         self.disease = Disease.objects.create(name="COVID-19", level_of_alertness=5)
         self.location = Location.objects.create(
             latitude=-6.9175, longitude=107.6191, name="Bandung"
@@ -146,29 +151,12 @@ class GenderDistAPITest(TestCase):
         Case.objects.create(gender='male', age=30, city='CityA', status='biasa', severity='insiden', disease=self.disease, location=self.location)
         Case.objects.create(gender='female', age=25, city='CityB', status='minimal', severity='mortalitas', disease=self.disease, location=self.location)
         Case.objects.create(gender='male', age=40, city='CityC', status='bahaya', severity='hospitalisasi', disease=self.disease, location=self.location)
-    
+
     def test_get_gender_dist(self):
-        response = self.client.get('/api/gender-distribution/')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        expected_data = {
-            'male': 2, 'female': 1
+        gender_dist = self.service.get_gender_dist()
+        expected_res = {
+            'male': 2,
+            'female': 1
         }
-        self.assertEqual(response.data, expected_data)
-    
-    def test_get_gender_dist_empty(self):
-        Case.objects.all().delete()
-        response = self.client.get('/api/gender-distribution/')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        expected_data = {
-            'male': 0,
-            'female': 0
-        }
-        self.assertEqual(response.data, expected_data)
 
-    @patch('pt_backend.services.GenderDistributionService.get_gender_distribution')
-    def test_get_gender_dist_exception(self, mock_get_gender_dist):
-        mock_get_gender_dist.side_effect = Exception("Database error")
-
-        response = self.client.get('/api/gender-distribution/')
-        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
-        self.assertEqual(response.json(), {"error": "An unexpected error occurred. Please try again later."})
+        self.assertEqual(expected_res, gender_dist)

--- a/pt_backend/tests/test_views.py
+++ b/pt_backend/tests/test_views.py
@@ -160,3 +160,25 @@ class GenderDistAPITest(TestCase):
         }
 
         self.assertEqual(expected_res, gender_dist)
+    
+    @patch('pt_backend.services.CaseService.get_gender_dist')
+    def test_get_gender_dist_exception(self, mock_get_gender_dist):
+        mock_get_gender_dist.return_value = {
+            'male': 2,
+            'female': 1
+        }
+
+        response = self.client.get('/api/cases/gender-distribution/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {
+            'male': 2,
+            'female': 1
+        })
+
+    @patch('pt_backend.services.CaseService.get_gender_dist')
+    def test_get_gender_dist_exception(self, mock_get_gender_dist):
+        mock_get_gender_dist.side_effect = Exception("Database error")
+
+        response = self.client.get('/api/cases/gender-distribution/')
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.json(), {"error": "An unexpected error occurred. Please try again later."})

--- a/pt_backend/tests/test_views.py
+++ b/pt_backend/tests/test_views.py
@@ -157,6 +157,12 @@ class GenderDistAPITest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), {'male': 2, 'female': 1})
     
+    def test_get_gender_dist_if_invalid_gender(self):
+        Case.objects.create(gender='BLABLA', age=30, city='CityA', status='biasa', severity='insiden', disease=self.disease, location=self.location)
+        response = self.client.get('/api/cases/gender-distribution/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {'male':2, 'female':1}) #buat cek klo ada yg ga valid masi return gender yg valid atau nggak
+
     @patch('pt_backend.services.CaseService.get_gender_dist')
     def test_get_gender_dist_exception(self, mock_get_gender_dist):
         mock_get_gender_dist.return_value = {

--- a/pt_backend/tests/test_views.py
+++ b/pt_backend/tests/test_views.py
@@ -146,7 +146,7 @@ class GenderDistAPITest(TestCase):
 
         self.disease = Disease.objects.create(name="COVID-19", level_of_alertness=5)
         self.location = Location.objects.create(
-            latitude=-6.9175, longitude=107.6191, name="Bandung"
+            latitude=-6.9175, longitude=107.6191, city="Bandung"
         )
         Case.objects.create(gender='male', age=30, city='CityA', status='biasa', severity='insiden', disease=self.disease, location=self.location)
         Case.objects.create(gender='female', age=25, city='CityB', status='minimal', severity='mortalitas', disease=self.disease, location=self.location)

--- a/pt_backend/urls.py
+++ b/pt_backend/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import AllCaseLocationsView, FiltersView
+from .views import AllCaseLocationsView, FiltersView, CaseGenderView
 
 urlpatterns = [
     path('cases/locations/', AllCaseLocationsView.as_view(), name='all-case-locations'),
     path('api/filters/', FiltersView.as_view(), name='filters'),
+    path('api/cases/gender-distribution/', CaseGenderView.as_view(), name='gender-distribution')
 ]

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -6,7 +6,10 @@ from .services import CacheService, CaseService
 from .filter.service import CaseFilterService
 from .repositories import CaseRepository, DiseaseRepository, LocationRepository, NewsRepository
 from .authentication import APIKeyAuthentication
+import logging
 
+logger = logging.getLogger(__name__)
+INTERNAL_ERROR_MESSAGE = "An unexpected error occurred. Please try again later."
 
 class AllCaseLocationsView(APIView):
     authentication_classes = [APIKeyAuthentication]
@@ -30,7 +33,7 @@ class AllCaseLocationsView(APIView):
             return Response(serialized_data, status=status.HTTP_200_OK)
         except Exception as e:
             print(e)
-            return Response({"error": "An unexpected error occurred. Please try again later."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"error": INTERNAL_ERROR_MESSAGE}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def post(self, request):
         try:
@@ -42,7 +45,7 @@ class AllCaseLocationsView(APIView):
 
             if not cases:
                 return Response(
-                    {"error": "No case locations found matching the filters"},
+                    {"error": INTERNAL_ERROR_MESSAGE},
                     status=status.HTTP_404_NOT_FOUND
                 )
 
@@ -52,7 +55,7 @@ class AllCaseLocationsView(APIView):
             )
         except Exception as e:
             return Response(
-                {"error": "An unexpected error occurred. Please try again later."},
+                {"error": INTERNAL_ERROR_MESSAGE},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
 
@@ -96,4 +99,5 @@ class CaseGenderView(APIView):
             serialized_data = GenderDistributionSerializer(gender_distribution)
             return Response(serialized_data.data, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({"error": "An unexpected error occurred. Please try again later."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            logger.error(f"Error in get method: {e}", exc_info=True)
+            return Response({"error": INTERNAL_ERROR_MESSAGE}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -1,7 +1,7 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
-from .serializers import CaseLocationSerializer
+from .serializers import CaseLocationSerializer, GenderDistributionSerializer
 from .services import CacheService, CaseService
 from .filter.service import CaseFilterService
 from .repositories import CaseRepository, DiseaseRepository, LocationRepository, NewsRepository
@@ -93,7 +93,7 @@ class CaseGenderView(APIView):
     def get(self, request):
         try:
             gender_distribution = self.service.get_gender_dist()
-
-            return Response(gender_distribution, status=status.HTTP_200_OK)
+            serialized_data = GenderDistributionSerializer(gender_distribution)
+            return Response(serialized_data.data, status=status.HTTP_200_OK)
         except Exception as e:
             return Response({"error": "An unexpected error occurred. Please try again later."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -97,7 +97,10 @@ class CaseGenderView(APIView):
         try:
             gender_distribution = self.service.get_gender_dist()
             serialized_data = GenderDistributionSerializer(gender_distribution)
-            return Response(serialized_data.data, status=status.HTTP_200_OK)
+            response_data = {
+                "gender_distribution": serialized_data.data
+            }
+            return Response(response_data, status=status.HTTP_200_OK)
         except Exception as e:
             logger.error(f"Error in get method: {e}", exc_info=True)
             return Response({"error": INTERNAL_ERROR_MESSAGE}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -79,3 +79,21 @@ class FiltersView(APIView):
             return Response(response_data, status=status.HTTP_200_OK)
         except Exception as e:
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+class CaseGenderView(APIView):
+    authentication_classes = [APIKeyAuthentication]
+    permission_classes = []
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        repository = CaseRepository()
+        cache_service = CacheService()
+        self.service = CaseService(repository, cache_service)
+    
+    def get(self, request):
+        try:
+            gender_distribution = self.service.get_gender_dist()
+
+            return Response(gender_distribution, status=status.HTTP_200_OK)
+        except Exception as e:
+            return Response({"error": "An unexpected error occurred. Please try again later."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
# Implementation of getting gender distribution from cases

## 📌 Summary  
This PR introduces functionality to retrieve the gender distribution from reported cases. The implementation allows us to analyze and visualize which gender is most represented in the case reports.

## 🔧 Changes Implemented  
-Created a new view for retrieving gender distribution from the reported cases.
- Integrated GenderDistributionSerializer to properly serialize the gender distribution data for API responses.
- Added get_gender_dist method in CaseService to calculate the count of cases based on gender.
-  Added edge case to ensure only valid genders (male and female) are the only ones counted.
- Implemented error handling for the gender distribution endpoint, returning appropriate 500 Internal Server Error responses in case of failures.
- Updated project documentation to include setup instructions and usage guidelines for the new API endpoint.

## 🎯 Usage & Benefits  
✅ Gender Distribution Insight – Easily retrieve gender distribution from reported cases through the API endpoint /api/cases/gender-distribution/.
✅ Data Serialization – Properly serialize the data using GenderDistributionSerializer for consistent and accurate API responses.
✅ Error Handling – Ensures graceful error handling with clear error messages and appropriate HTTP status codes.

## 🛠️ How to Test  
1. Install dependencies (if not installed yet):  
   ```bash
    pip install -r requirements.txt

2. Apply Migrations:
   ```bash
   python manage.py migrate

3. Start the Django server:
   ```bash
   python manage.py runserver

4. Open postman and enter the x-api-key on headers

5. Test the endpoint:
   ```bash
   http://127.0.0.1:8000/api/cases/gender-distribution/
