### PR TITLE
[PBI D03] : Olah Data Berita Nasional

### DIFF
--- a/pt_backend/interfaces.py
+++ b/pt_backend/interfaces.py
@@ -22,3 +22,12 @@ class CacheInterface(ABC):
     @abstractmethod
     def delete(self, key):
         pass # pragma: no cover
+
+class NewsRepositoryInterface(ABC):
+    @abstractmethod
+    def get_top_five_national_portals(self):
+        pass # pragma: no cover
+
+    @abstractmethod
+    def get_national_portal_statistics(self):
+        pass # pragma: no cover

--- a/pt_backend/repositories.py
+++ b/pt_backend/repositories.py
@@ -1,5 +1,6 @@
 from .models import Case, Disease, Location, News
 from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import Count
 from .models import Case
 from .interfaces import CaseRepositoryInterface
 
@@ -33,7 +34,22 @@ class NewsRepository:
             return list(news)
         except ObjectDoesNotExist:
             return {"error": "Error retrieving news"}
-
+        
+    def get_top_five_national_portals(self):
+        try:
+            portals = News.objects.filter(
+                type="Nasional"
+            ).values('portal').annotate(
+                count=Count('id')
+            ).order_by('-count', 'portal')[:5]
+            
+            if not portals.exists():
+                return []
+                
+            return portals
+        except ObjectDoesNotExist:
+            return {"error": "Error retrieving national portals"}
+    
 class CaseRepository(CaseRepositoryInterface):
     def get_all_locations(self):
         return Case.get_all_locations()

--- a/pt_backend/repositories.py
+++ b/pt_backend/repositories.py
@@ -2,7 +2,7 @@ from .models import Case, Disease, Location, News
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Count
 from .models import Case
-from .interfaces import CaseRepositoryInterface
+from .interfaces import CaseRepositoryInterface, NewsRepositoryInterface
 
 class DiseaseRepository:
     def get_all_diseases_name(self):
@@ -25,7 +25,7 @@ class LocationRepository:
             return {"error": "Error retrieving locations"}
         
 
-class NewsRepository:
+class NewsRepository(NewsRepositoryInterface):
     def get_all_news_name(self):
         try:
             news = News.objects.values_list("portal", flat=True).distinct()

--- a/pt_backend/repositories.py
+++ b/pt_backend/repositories.py
@@ -50,6 +50,25 @@ class NewsRepository:
         except ObjectDoesNotExist:
             return {"error": "Error retrieving national portals"}
     
+    def get_national_portal_statistics(self):
+        try:
+            # Get portals with news count and distinct disease count            
+            portal_stats = News.objects.filter(
+                type="Nasional"
+            ).values(
+                'portal'
+            ).annotate(
+                news_count=Count('id'),
+                disease_count=Count('case__disease', distinct=True)
+            ).order_by('-news_count')
+            
+            if not portal_stats.exists():
+                return []
+                
+            return portal_stats
+        except ObjectDoesNotExist:
+            return {"error": "Error retrieving national portal statistics"}
+
 class CaseRepository(CaseRepositoryInterface):
     def get_all_locations(self):
         return Case.get_all_locations()

--- a/pt_backend/serializers.py
+++ b/pt_backend/serializers.py
@@ -9,3 +9,8 @@ class CaseLocationSerializer(serializers.Serializer):
 class TopPortalSerializer(serializers.Serializer):
     portal = serializers.CharField()
     count = serializers.IntegerField()
+
+class PortalStatisticsSerializer(serializers.Serializer):
+    portal = serializers.CharField()
+    news_count = serializers.IntegerField()
+    disease_count = serializers.IntegerField()

--- a/pt_backend/serializers.py
+++ b/pt_backend/serializers.py
@@ -6,3 +6,6 @@ class CaseLocationSerializer(serializers.Serializer):
     location__latitude = serializers.DecimalField(max_digits=8, decimal_places=6)
     city = serializers.CharField(max_length=255)
 
+class TopPortalSerializer(serializers.Serializer):
+    portal = serializers.CharField()
+    count = serializers.IntegerField()

--- a/pt_backend/services.py
+++ b/pt_backend/services.py
@@ -26,3 +26,13 @@ class CacheService(CacheInterface):
 
     def delete(self, key):
         cache.delete(key)
+
+class NewsService:
+    def __init__(self, repository):
+        self.repository = repository
+
+    def get_top_national_portals(self):
+        try:
+            return self.repository.get_top_five_national_portals()
+        except Exception as e:
+            raise e

--- a/pt_backend/services.py
+++ b/pt_backend/services.py
@@ -32,13 +32,7 @@ class NewsService:
         self.repository = repository
 
     def get_top_national_portals(self):
-        try:
-            return self.repository.get_top_five_national_portals()
-        except Exception as e:
-            raise e
+        return self.repository.get_top_five_national_portals()
         
     def get_national_portal_statistics(self):
-        try:
-            return self.repository.get_national_portal_statistics()
-        except Exception as e:
-            raise e
+        return self.repository.get_national_portal_statistics()

--- a/pt_backend/services.py
+++ b/pt_backend/services.py
@@ -36,3 +36,9 @@ class NewsService:
             return self.repository.get_top_five_national_portals()
         except Exception as e:
             raise e
+        
+    def get_national_portal_statistics(self):
+        try:
+            return self.repository.get_national_portal_statistics()
+        except Exception as e:
+            raise e

--- a/pt_backend/tests/test_repository.py
+++ b/pt_backend/tests/test_repository.py
@@ -98,6 +98,130 @@ class NewsRepositoryTestCase(BaseTestCase):
         result = self.repository.get_all_news_name()
         self.assertEqual(result, {"error": "Error retrieving news"})
 
+
+class NewsRepositoryTopNationalPortalsTestCase(TestCase):
+    def setUp(self):
+        self.repository = NewsRepository()
+        
+        self.disease = Disease.objects.create(name="COVID-19", level_of_alertness=5)
+        self.location = Location.objects.create(
+            latitude=-6.9175, longitude=107.6191, city="Bandung"
+        )
+        self.case = Case.objects.create(
+            id=uuid.uuid4(), gender="Pria", age=30, city="Jakarta", status="kematian", disease=self.disease, location=self.location
+        )
+
+        # Create 6 news objects
+        self.news_national = [
+            News.objects.create(
+                id=uuid.uuid4(),
+                portal="kompas.com",
+                type="Nasional",
+                title="News 1",
+                content="Content 1",
+                url="https://kompas.com/1",
+                author="Author 1",
+                case=self.case
+            ),
+            News.objects.create(
+                id=uuid.uuid4(),
+                portal="detik.com",
+                type="Nasional",
+                title="News 2",
+                content="Content 2",
+                url="https://detik.com/1",
+                author="Author 2",
+                case=self.case
+            ),
+            News.objects.create(
+                id=uuid.uuid4(),
+                portal="cnn.com",
+                type="Nasional",
+                title="News 3",
+                content="Content 3",
+                url="https://cnn.com/1",
+                author="Author 3",
+                case=self.case
+            ),
+            News.objects.create(
+                id=uuid.uuid4(),
+                portal="tempo.co",
+                type="Nasional",
+                title="News 4",
+                content="Content 4",
+                url="https://tempo.co/1",
+                author="Author 4",
+                case=self.case
+            ),
+            News.objects.create(
+                id=uuid.uuid4(),
+                portal="republika.co.id",
+                type="Nasional",
+                title="News 5",
+                content="Content 5",
+                url="https://republika.co.id/1",
+                author="Author 5",
+                case=self.case
+            ),
+            News.objects.create(
+                id=uuid.uuid4(),
+                portal="tribun.com",
+                type="Nasional",
+                title="News 6",
+                content="Content 6",
+                url="https://tribun.com/1",
+                author="Author 6",
+                case=self.case
+            )
+        ]
+
+    def test_get_top_five_national_portals(self):
+        top_portals = self.repository.get_top_five_national_portals()
+        self.assertEqual(top_portals.count(), 5)
+
+        portals = [item["portal"] for item in top_portals]
+        self.assertEqual(len(portals), 5)
+
+        for portal in top_portals:
+            self.assertEqual(portal["count"], 1)
+
+        self.assertNotIn("tribun.com", portals)
+
+    def test_get_top_five_national_portals_empty(self):
+        News.objects.all().delete()
+
+        top_portals = self.repository.get_top_five_national_portals()
+        self.assertEqual(top_portals, [])
+
+    def test_get_top_five_national_portals_less_than_five(self):
+        News.objects.filter(portal="tribun.com").delete()
+        News.objects.filter(portal="republika.co.id").delete()
+
+        top_portals = self.repository.get_top_five_national_portals()
+        self.assertEqual(top_portals.count(), 4)
+
+        portals = [item["portal"] for item in top_portals]
+        self.assertEqual(len(portals), 4)
+
+        for portal in top_portals:
+            self.assertEqual(portal["count"], 1)
+
+        self.assertNotIn("tribun.com", portals)
+        self.assertNotIn("replubika.co.id", portals)
+
+    @patch('pt_backend.models.News.objects.filter')
+    def test_get_top_five_national_portals_object_does_not_exist(self, mock_filter):
+        mock_filter.side_effect = ObjectDoesNotExist()
+        
+        result = self.repository.get_top_five_national_portals()
+        
+        self.assertEqual(
+            result, 
+            {"error": "Error retrieving national portals"}
+        )
+        
+        mock_filter.assert_called_once_with(type="Nasional")
+
 class CaseRepositoryTestCase(TestCase):
     def setUp(self):
         self.disease = Disease.objects.create(name="COVID-19", level_of_alertness=5)

--- a/pt_backend/tests/test_repository.py
+++ b/pt_backend/tests/test_repository.py
@@ -222,6 +222,137 @@ class NewsRepositoryTopNationalPortalsTestCase(TestCase):
         
         mock_filter.assert_called_once_with(type="Nasional")
 
+class NewsRepositoryNationalPortalStatisticsTestCase(TestCase):
+    def setUp(self):
+        self.repository = NewsRepository()
+        
+        # Create diseases
+        self.disease1 = Disease.objects.create(name="COVID-19", level_of_alertness=5)
+        self.disease2 = Disease.objects.create(name="Ebola", level_of_alertness=5)
+        self.disease3 = Disease.objects.create(name="Malaria", level_of_alertness=4)
+        
+        # Create locations
+        self.location = Location.objects.create(
+            latitude=-6.9175, longitude=107.6191, city="Bandung", province="West Java"
+        )
+        
+        # Create cases
+        self.case1 = Case.objects.create(
+            id=uuid.uuid4(), gender="Pria", age=30, city="Jakarta", 
+            status="Bahaya", severity="hospitalisasi", disease=self.disease1, location=self.location
+        )
+        self.case2 = Case.objects.create(
+            id=uuid.uuid4(), gender="Wanita", age=25, city="Surabaya", 
+            status="Bahaya", severity="mortalitas", disease=self.disease2, location=self.location
+        )
+        self.case3 = Case.objects.create(
+            id=uuid.uuid4(), gender="Pria", age=40, city="Bandung", 
+            status="Biasa", severity="insiden", disease=self.disease3, location=self.location
+        )
+        
+        # Create national news from different portals with various diseases
+        self.news_kompas = [
+            News.objects.create(
+                portal="kompas.com", type="Nasional", title="News K1",
+                content="Content K1", url="https://kompas.com/1", author="Author K1", case=self.case1
+            ),
+            News.objects.create(
+                portal="kompas.com", type="Nasional", title="News K2",
+                content="Content K2", url="https://kompas.com/2", author="Author K2", case=self.case1
+            ),
+            News.objects.create(
+                portal="kompas.com", type="Nasional", title="News K3",
+                content="Content K3", url="https://kompas.com/3", author="Author K3", case=self.case2
+            )
+        ]
+        
+        self.news_detik = [
+            News.objects.create(
+                portal="detik.com", type="Nasional", title="News D1",
+                content="Content D1", url="https://detik.com/1", author="Author D1", case=self.case1
+            ),
+            News.objects.create(
+                portal="detik.com", type="Nasional", title="News D2",
+                content="Content D2", url="https://detik.com/2", author="Author D2", case=self.case2
+            )
+        ]
+        
+        self.news_cnn = [
+            News.objects.create(
+                portal="cnn.com", type="Nasional", title="News C1",
+                content="Content C1", url="https://cnn.com/1", author="Author C1", case=self.case3
+            )
+        ]
+        
+        # Create non-national news (shouldn't be included in results)
+        self.news_international = News.objects.create(
+            portal="kompas.com", type="International", title="News Int",
+            content="Content Int", url="https://kompas.com/int", author="Author Int", case=self.case1
+        )
+
+    def test_get_national_portal_statistics_success(self):
+        # Get portal statistics
+        portal_stats = self.repository.get_national_portal_statistics()
+        
+        # Convert to dictionary for easier testing
+        stats_dict = {stat['portal']: stat for stat in portal_stats}
+        
+        # Verify kompas.com data
+        self.assertIn('kompas.com', stats_dict)
+        self.assertEqual(stats_dict['kompas.com']['news_count'], 3)
+        self.assertEqual(stats_dict['kompas.com']['disease_count'], 2)  # COVID-19 and Ebola
+        
+        # Verify detik.com data
+        self.assertIn('detik.com', stats_dict)
+        self.assertEqual(stats_dict['detik.com']['news_count'], 2)
+        self.assertEqual(stats_dict['detik.com']['disease_count'], 2)  # COVID-19 and Ebola
+        
+        # Verify cnn.com data
+        self.assertIn('cnn.com', stats_dict)
+        self.assertEqual(stats_dict['cnn.com']['news_count'], 1)
+        self.assertEqual(stats_dict['cnn.com']['disease_count'], 1)  # Malaria
+        
+        # Verify ordering (by news_count descending)
+        portals = [stat['portal'] for stat in portal_stats]
+        self.assertEqual(portals, ['kompas.com', 'detik.com', 'cnn.com'])
+
+    def test_get_national_portal_statistics_empty(self):
+        # Delete all news
+        News.objects.all().delete()
+        
+        # Get stats
+        portal_stats = self.repository.get_national_portal_statistics()
+        
+        # Verify empty result
+        self.assertEqual(portal_stats, [])
+
+    def test_get_national_portal_statistics_only_international_news(self):
+        # Delete all national news, leaving only international
+        News.objects.filter(type="Nasional").delete()
+        
+        # Get stats
+        portal_stats = self.repository.get_national_portal_statistics()
+        
+        # Verify empty result since we only have international news
+        self.assertEqual(portal_stats, [])
+
+    @patch('pt_backend.models.News.objects.filter')
+    def test_get_national_portal_statistics_object_does_not_exist(self, mock_filter):
+        # Mock to raise exception
+        mock_filter.side_effect = ObjectDoesNotExist()
+        
+        # Call method
+        result = self.repository.get_national_portal_statistics()
+        
+        # Verify error response
+        self.assertEqual(
+            result, 
+            {"error": "Error retrieving national portal statistics"}
+        )
+        
+        # Verify filter was called with correct parameter
+        mock_filter.assert_called_once_with(type="Nasional")
+
 class CaseRepositoryTestCase(TestCase):
     def setUp(self):
         self.disease = Disease.objects.create(name="COVID-19", level_of_alertness=5)

--- a/pt_backend/tests/test_views.py
+++ b/pt_backend/tests/test_views.py
@@ -159,50 +159,26 @@ class TopNationalPortalsViewTest(TestCase):
             {"portal": "republika.co.id", "count": 2}
         ]
         self.mock_service_instance.get_top_national_portals.return_value = mock_data
-
+    
         # Make request
         response = self.client.get('/news/top-national-portals/')
-
+    
         # Assertions
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), mock_data)
+        self.assertEqual(response.json(), {"national_top": mock_data})  # Changed to match new structure
         self.mock_service_instance.get_top_national_portals.assert_called_once()
-
+    
     def test_get_top_portals_empty_result(self):
         # Mock empty result
         self.mock_service_instance.get_top_national_portals.return_value = []
-
+    
         # Make request
         response = self.client.get('/news/top-national-portals/')
-
+    
         # Assertions
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), [])
-
-    def test_get_top_portals_repository_error(self):
-        # Mock service error
-        self.mock_service_instance.get_top_national_portals.side_effect = Exception("Database error")
-
-        # Make request
-        response = self.client.get('/news/top-national-portals/')
-
-        # Assertions
-        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
-        self.assertEqual(response.json(), {"error": "An error occurred while fetching top portals"})
-
-    def test_get_top_portals_error_response_from_repository(self):
-        """Test handling of error response object from repository"""
-        # Mock repository returning an error dictionary
-        error_response = {"error": "Error retrieving national portals"}
-        self.mock_service_instance.get_top_national_portals.return_value = error_response
-
-        # Make request
-        response = self.client.get('/news/top-national-portals/')
-
-        # Assertions
-        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
-        self.assertEqual(response.json(), {"error": "An error occurred while fetching top portals"})
-
+        self.assertEqual(response.json(), {"national_top": []})  # Changed to match new structure
+    
     def test_get_top_portals_queryset_conversion(self):
         """Test queryset conversion in view - covers views.py line 108"""
         # Create a mock queryset-like object
@@ -230,8 +206,34 @@ class TopNationalPortalsViewTest(TestCase):
         
         # Assertions
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # Verify the data was properly converted and serialized
-        self.assertTrue(isinstance(response.json(), list))
+        # Verify the response structure and that it's a dictionary with a list under "national_top"
+        self.assertTrue(isinstance(response.json(), dict))  # Changed to check dict instead of list
+        self.assertTrue("national_top" in response.json())
+        self.assertTrue(isinstance(response.json()["national_top"], list))  # Check that value is a list
+
+    def test_get_top_portals_repository_error(self):
+        # Mock service error
+        self.mock_service_instance.get_top_national_portals.side_effect = Exception("Database error")
+
+        # Make request
+        response = self.client.get('/news/top-national-portals/')
+
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.json(), {"error": "An error occurred while fetching top portals"})
+
+    def test_get_top_portals_error_response_from_repository(self):
+        """Test handling of error response object from repository"""
+        # Mock repository returning an error dictionary
+        error_response = {"error": "Error retrieving national portals"}
+        self.mock_service_instance.get_top_national_portals.return_value = error_response
+
+        # Make request
+        response = self.client.get('/news/top-national-portals/')
+
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.json(), {"error": "An error occurred while fetching top portals"})
 
     def test_news_service_exception_propagation(self):
         """Test service properly propagates exceptions to the view"""

--- a/pt_backend/tests/test_views.py
+++ b/pt_backend/tests/test_views.py
@@ -252,3 +252,120 @@ class TopNationalPortalsViewTest(TestCase):
             self.mock_news_service = self.patcher.start()
             self.mock_service_instance = Mock()
             self.mock_news_service.return_value = self.mock_service_instance
+
+class NationalPortalStatisticsViewTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.api_key = os.getenv("SECRET_API_KEY", "test-api-key")
+        self.client.credentials(HTTP_X_API_KEY=self.api_key)
+        
+        # Setup mock repository and patch NewsService
+        self.patcher = patch('pt_backend.views.NewsService')
+        self.mock_news_service = self.patcher.start()
+        self.mock_service_instance = Mock()
+        self.mock_news_service.return_value = self.mock_service_instance
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_get_portal_statistics_success(self):
+        # Mock data that would come from service
+        mock_data = [
+            {"portal": "kompas.com", "news_count": 15, "disease_count": 3},
+            {"portal": "detik.com", "news_count": 12, "disease_count": 2},
+            {"portal": "cnn.com", "news_count": 8, "disease_count": 4},
+            {"portal": "tempo.co", "news_count": 6, "disease_count": 1},
+            {"portal": "republika.co.id", "news_count": 5, "disease_count": 2}
+        ]
+        self.mock_service_instance.get_national_portal_statistics.return_value = mock_data
+
+        # Make request
+        response = self.client.get('/news/national-portal-stats/')
+
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), mock_data)
+        self.mock_service_instance.get_national_portal_statistics.assert_called_once()
+
+    def test_get_portal_statistics_empty_result(self):
+        # Mock empty result
+        self.mock_service_instance.get_national_portal_statistics.return_value = []
+
+        # Make request
+        response = self.client.get('/news/national-portal-stats/')
+
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), [])
+
+    def test_get_portal_statistics_repository_error(self):
+        # Mock service error
+        self.mock_service_instance.get_national_portal_statistics.side_effect = Exception("Database error")
+
+        # Make request
+        response = self.client.get('/news/national-portal-stats/')
+
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.json(), {"error": "An error occurred while fetching portal statistics"})
+
+    def test_get_portal_statistics_error_response_from_repository(self):
+        # Mock repository returning an error dictionary
+        error_response = {"error": "Error retrieving national portal statistics"}
+        self.mock_service_instance.get_national_portal_statistics.return_value = error_response
+
+        # Make request
+        response = self.client.get('/news/national-portal-stats/')
+
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.json(), {"error": "An error occurred while fetching portal statistics"})
+
+    def test_get_portal_statistics_queryset_conversion(self):
+        # Create a mock queryset-like object
+        class MockQuerySet:
+            def __init__(self, data):
+                self.data = data
+            def values(self):
+                return self.data
+            def __iter__(self):
+                return iter(self.data)
+            def __bool__(self):
+                return bool(self.data)
+        
+        # Create mock data with queryset-like behavior
+        mock_data = MockQuerySet([
+            {"portal": "kompas.com", "news_count": 15, "disease_count": 3},
+            {"portal": "detik.com", "news_count": 12, "disease_count": 2}
+        ])
+        
+        # Set return value with queryset-like object
+        self.mock_service_instance.get_national_portal_statistics.return_value = mock_data
+        
+        # Make request
+        response = self.client.get('/news/national-portal-stats/')
+        
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Verify the data was properly converted and serialized
+        self.assertTrue(isinstance(response.json(), list))
+        self.assertEqual(len(response.json()), 2)
+
+    def test_service_propagates_exceptions(self):
+        # Stop the existing patcher temporarily
+        self.patcher.stop()
+        
+        try:
+            # Test the actual NewsService class directly
+            mock_repository = Mock()
+            mock_repository.get_national_portal_statistics.side_effect = Exception("Repository error")
+            
+            # Test if the service correctly re-raises the exception
+            with self.assertRaises(Exception):
+                service = NewsService(mock_repository)
+                service.get_national_portal_statistics()
+        finally:
+            # Restart the patcher for other tests
+            self.mock_news_service = self.patcher.start()
+            self.mock_service_instance = Mock()
+            self.mock_news_service.return_value = self.mock_service_instance

--- a/pt_backend/tests/test_views.py
+++ b/pt_backend/tests/test_views.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from rest_framework.test import APIClient
 from rest_framework import status
 from pt_backend.models import Case, Location, Disease
-from pt_backend.services import CacheService
+from pt_backend.services import CacheService, NewsService
 import uuid
 import os
 from unittest.mock import patch, Mock
@@ -132,3 +132,123 @@ class CaseFilterPostTest(TestCase):
         response = self.client.post('/cases/locations/', {}, format='json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.json(), {"detail": "Invalid API Key"})
+
+
+class TopNationalPortalsViewTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.api_key = os.getenv("SECRET_API_KEY", "test-api-key")
+        self.client.credentials(HTTP_X_API_KEY=self.api_key)
+        
+        # Setup mock repository and patch NewsService to use our mock
+        self.patcher = patch('pt_backend.views.NewsService')
+        self.mock_news_service = self.patcher.start()
+        self.mock_service_instance = Mock()
+        self.mock_news_service.return_value = self.mock_service_instance
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_get_top_portals_success(self):
+        # Mock data that would come from repository (through service)
+        mock_data = [
+            {"portal": "kompas.com", "count": 10},
+            {"portal": "detik.com", "count": 8},
+            {"portal": "tempo.co", "count": 6},
+            {"portal": "cnn.com", "count": 4},
+            {"portal": "republika.co.id", "count": 2}
+        ]
+        self.mock_service_instance.get_top_national_portals.return_value = mock_data
+
+        # Make request
+        response = self.client.get('/news/top-national-portals/')
+
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), mock_data)
+        self.mock_service_instance.get_top_national_portals.assert_called_once()
+
+    def test_get_top_portals_empty_result(self):
+        # Mock empty result
+        self.mock_service_instance.get_top_national_portals.return_value = []
+
+        # Make request
+        response = self.client.get('/news/top-national-portals/')
+
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), [])
+
+    def test_get_top_portals_repository_error(self):
+        # Mock service error
+        self.mock_service_instance.get_top_national_portals.side_effect = Exception("Database error")
+
+        # Make request
+        response = self.client.get('/news/top-national-portals/')
+
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.json(), {"error": "An error occurred while fetching top portals"})
+
+    def test_get_top_portals_error_response_from_repository(self):
+        """Test handling of error response object from repository"""
+        # Mock repository returning an error dictionary
+        error_response = {"error": "Error retrieving national portals"}
+        self.mock_service_instance.get_top_national_portals.return_value = error_response
+
+        # Make request
+        response = self.client.get('/news/top-national-portals/')
+
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.json(), {"error": "An error occurred while fetching top portals"})
+
+    def test_get_top_portals_queryset_conversion(self):
+        """Test queryset conversion in view - covers views.py line 108"""
+        # Create a mock queryset-like object
+        class MockQuerySet:
+            def __init__(self, data):
+                self.data = data
+            def values(self):
+                return self.data
+            def __iter__(self):
+                return iter(self.data)
+            def __bool__(self):
+                return bool(self.data)
+        
+        # Create mock data with queryset-like behavior
+        mock_data = MockQuerySet([
+            {"portal": "kompas.com", "count": 10},
+            {"portal": "detik.com", "count": 8}
+        ])
+        
+        # Set return value with queryset-like object
+        self.mock_service_instance.get_top_national_portals.return_value = mock_data
+        
+        # Make request
+        response = self.client.get('/news/top-national-portals/')
+        
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Verify the data was properly converted and serialized
+        self.assertTrue(isinstance(response.json(), list))
+
+    def test_news_service_exception_propagation(self):
+        """Test service properly propagates exceptions to the view"""
+        # Stop the existing patcher temporarily
+        self.patcher.stop()
+        
+        try:
+            # Test the actual NewsService class directly without mocking
+            mock_repository = Mock()
+            mock_repository.get_top_five_national_portals.side_effect = Exception("Repository error")
+            
+            # Test if the service correctly re-raises the exception
+            with self.assertRaises(Exception):
+                service = NewsService(mock_repository)
+                service.get_top_national_portals()
+        finally:
+            # Restart the patcher for other tests
+            self.mock_news_service = self.patcher.start()
+            self.mock_service_instance = Mock()
+            self.mock_news_service.return_value = self.mock_service_instance

--- a/pt_backend/urls.py
+++ b/pt_backend/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import AllCaseLocationsView, FiltersView
+from .views import AllCaseLocationsView, FiltersView, TopNationalPortalsView
 
 urlpatterns = [
     path('cases/locations/', AllCaseLocationsView.as_view(), name='all-case-locations'),
     path('api/filters/', FiltersView.as_view(), name='filters'),
+    path('news/top-national-portals/', TopNationalPortalsView.as_view(), name='top-national-portals'),
 ]

--- a/pt_backend/urls.py
+++ b/pt_backend/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import AllCaseLocationsView, FiltersView, TopNationalPortalsView
+from .views import AllCaseLocationsView, FiltersView, NationalPortalStatisticsView, TopNationalPortalsView
 
 urlpatterns = [
     path('cases/locations/', AllCaseLocationsView.as_view(), name='all-case-locations'),
     path('api/filters/', FiltersView.as_view(), name='filters'),
     path('news/top-national-portals/', TopNationalPortalsView.as_view(), name='top-national-portals'),
+    path('news/national-portal-stats/', NationalPortalStatisticsView.as_view(), name='national-portal-stats'),
 ]

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -1,8 +1,8 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
-from .serializers import CaseLocationSerializer
-from .services import CacheService, CaseService
+from .serializers import CaseLocationSerializer, TopPortalSerializer
+from .services import CacheService, CaseService, NewsService
 from .filter.service import CaseFilterService
 from .repositories import CaseRepository, DiseaseRepository, LocationRepository, NewsRepository
 from .authentication import APIKeyAuthentication
@@ -79,3 +79,39 @@ class FiltersView(APIView):
             return Response(response_data, status=status.HTTP_200_OK)
         except Exception as e:
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        
+
+class TopNationalPortalsView(APIView):
+    authentication_classes = [APIKeyAuthentication]
+    permission_classes = []
+    serializer_class = TopPortalSerializer
+
+    def get(self, request):
+        try:
+            repository = NewsRepository()
+            service = NewsService(repository)
+            top_portals = service.get_top_national_portals()
+            
+            # Check if we got an error response from repository
+            if isinstance(top_portals, dict) and 'error' in top_portals:
+                return Response(
+                    {"error": "An error occurred while fetching top portals"},
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                )
+            
+            # Handle empty results
+            if not top_portals:
+                return Response([], status=status.HTTP_200_OK)
+                
+            # Convert queryset to list if needed
+            if hasattr(top_portals, 'values'):
+                top_portals = list(top_portals)
+                
+            serializer = self.serializer_class(top_portals, many=True)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+            
+        except Exception as e:
+            return Response(
+                {"error": "An error occurred while fetching top portals"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -101,14 +101,14 @@ class TopNationalPortalsView(APIView):
             
             # Handle empty results
             if not top_portals:
-                return Response([], status=status.HTTP_200_OK)
+                return Response({"national_top": []}, status=status.HTTP_200_OK)
                 
             # Convert queryset to list if needed
             if hasattr(top_portals, 'values'):
                 top_portals = list(top_portals)
                 
             serializer = self.serializer_class(top_portals, many=True)
-            return Response(serializer.data, status=status.HTTP_200_OK)
+            return Response({"national_top": serializer.data}, status=status.HTTP_200_OK)
             
         except Exception:
             return Response(

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -1,7 +1,7 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
-from .serializers import CaseLocationSerializer, TopPortalSerializer
+from .serializers import CaseLocationSerializer, PortalStatisticsSerializer, TopPortalSerializer
 from .services import CacheService, CaseService, NewsService
 from .filter.service import CaseFilterService
 from .repositories import CaseRepository, DiseaseRepository, LocationRepository, NewsRepository
@@ -113,5 +113,40 @@ class TopNationalPortalsView(APIView):
         except Exception as e:
             return Response(
                 {"error": "An error occurred while fetching top portals"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+        
+class NationalPortalStatisticsView(APIView):
+    authentication_classes = [APIKeyAuthentication]
+    permission_classes = []
+    serializer_class = PortalStatisticsSerializer
+
+    def get(self, request):
+        try:
+            repository = NewsRepository()
+            service = NewsService(repository)
+            portal_stats = service.get_national_portal_statistics()
+            
+            # Check if we got an error response from repository
+            if isinstance(portal_stats, dict) and 'error' in portal_stats:
+                return Response(
+                    {"error": "An error occurred while fetching portal statistics"},
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                )
+            
+            # Handle empty results
+            if not portal_stats:
+                return Response([], status=status.HTTP_200_OK)
+                
+            # Convert queryset to list if needed
+            if hasattr(portal_stats, 'values'):
+                portal_stats = list(portal_stats)
+                
+            serializer = self.serializer_class(portal_stats, many=True)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+            
+        except Exception as e:
+            return Response(
+                {"error": "An error occurred while fetching portal statistics"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -110,7 +110,7 @@ class TopNationalPortalsView(APIView):
             serializer = self.serializer_class(top_portals, many=True)
             return Response(serializer.data, status=status.HTTP_200_OK)
             
-        except Exception as e:
+        except Exception:
             return Response(
                 {"error": "An error occurred while fetching top portals"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -50,7 +50,7 @@ class AllCaseLocationsView(APIView):
                 self.serializer_class(cases, many=True).data,
                 status=status.HTTP_200_OK
             )
-        except Exception as e:
+        except Exception:
             return Response(
                 {"error": "An unexpected error occurred. Please try again later."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
@@ -145,7 +145,7 @@ class NationalPortalStatisticsView(APIView):
             serializer = self.serializer_class(portal_stats, many=True)
             return Response(serializer.data, status=status.HTTP_200_OK)
             
-        except Exception as e:
+        except Exception:
             return Response(
                 {"error": "An error occurred while fetching portal statistics"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR


### PR DESCRIPTION
## Feature: National News Portal Analytics

### Summary

This PR adds comprehensive analytics features for national news portals, enabling users to:

1. View the top 5 national news portals by article count
2. Access detailed statistics for all national news portals including article counts and disease coverage

The implementation follows TDD practices with complete test coverage and adheres to our established clean architecture patterns.

### Changes Implemented

- Added two new endpoints:
    - /news/top-national-portals/: Returns the 5 most active national news portals ranked by article count
    - /news/national-portal-stats/: Returns detailed statistics for all national news portals including article counts and disease counts
- Created repository methods:
    - get_top_five_national_portals(): Retrieves top 5 portals by news count
    - get_national_portal_statistics(): Retrieves all portals with news count and disease count
- Added service layer:
    - Extended NewsService with methods to support the new functionality
    - Proper error handling and data processing
- Created serializers:
    - TopPortalSerializer: For portal name and count data
    - PortalStatisticsSerializer: For extended portal statistics
- Comprehensive test coverage:
    - Repository tests for data access
    - Service tests for business logic
    - View tests for API behavior
    - URL tests for routing

### How to Use the API
Top National Portals
```
GET news/top-national-portals/
```
Response example:
```json
{
    "national_top": [
        {
            "portal": "Kompas",
            "count": 4
        },
        {
            "portal": "Detik",
            "count": 3
        },
        {
            "portal": "Antaranews",
            "count": 1
        },
        {
            "portal": "CNN Indonesia",
            "count": 1
        },
        {
            "portal": "IDN Times",
            "count": 1
        }
    ]
}
```
National Portal Statistics
```
GET news/national-portal-stats/
```
Response example:
```json
[
    {
        "portal": "kompas.com",
        "news_count": 15,
        "disease_count": 3
    },
    {
        "portal": "detik.com",
        "news_count": 12,
        "disease_count": 2
    },
    {
        "portal": "cnn.com",
        "news_count": 8,
        "disease_count": 4
    },
    {
        "portal": "tempo.co",
        "news_count": 6,
        "disease_count": 1
    },
    {
        "portal": "republika.co.id",
        "news_count": 5,
        "disease_count": 2
    }
]
```

Both endpoints require authentication using an API key and return HTTP 403 if unauthorized, HTTP 500 for server errors, and HTTP 200 with appropriate data on success.