### PR TITLE
[PBI-D05] Rangkuman kasus by jenis penyakit

### DIFF
--- a/pantau_tular/settings.py
+++ b/pantau_tular/settings.py
@@ -29,7 +29,7 @@ SECRET_KEY = os.getenv('SECRET_KEY')
 SECRET_API_KEY = os.getenv('SECRET_API_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
 ALLOWED_HOSTS = ["localhost", "127.0.0.1",".up.railway.app"]
 

--- a/pt_backend/repositories.py
+++ b/pt_backend/repositories.py
@@ -1,5 +1,6 @@
 from .models import Case, Disease, Location, News
 from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import Count
 from .models import Case
 from .interfaces import CaseRepositoryInterface
 
@@ -12,6 +13,15 @@ class DiseaseRepository:
             return list(diseases)
         except ObjectDoesNotExist:
             return {"error": "Error retrieving diseases"}
+    
+    def get_disease_severity_stats(self):
+        try:
+            diseases = Disease.objects.prefetch_related('cases')
+            result = []
+            return result
+        except Exception as e:
+            print(f"Repository ERROR: {str(e)}")
+            return {"error": "Error retrieving disease severity statistics"}
 
 class LocationRepository:
     def get_all_locations_name(self):
@@ -23,7 +33,6 @@ class LocationRepository:
         except ObjectDoesNotExist:
             return {"error": "Error retrieving locations"}
         
-
 class NewsRepository:
     def get_all_news_name(self):
         try:

--- a/pt_backend/repositories.py
+++ b/pt_backend/repositories.py
@@ -1,7 +1,6 @@
 from .models import Case, Disease, Location, News
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Count, Case as DjangoCase, When, IntegerField, Sum
-from django.db.models import Count
 from .interfaces import CaseRepositoryInterface
 
 class DiseaseRepository:
@@ -16,9 +15,6 @@ class DiseaseRepository:
     
     def get_disease_severity_stats(self):
         try:
-            # Single efficient query with annotations
-            from django.db.models import Count, Case as DjangoCase, When, IntegerField, Sum
-            
             diseases = Disease.objects.annotate(
                 hospitalisasi_count=Sum(
                     DjangoCase(
@@ -60,7 +56,6 @@ class DiseaseRepository:
                 
             return result
         except Exception as e:
-            print(f"Repository ERROR: {str(e)}")
             return {"error": "Error retrieving disease severity statistics"}
 
 

--- a/pt_backend/repositories.py
+++ b/pt_backend/repositories.py
@@ -55,7 +55,7 @@ class DiseaseRepository:
                 result.append(disease_info)
                 
             return result
-        except Exception as e:
+        except Exception:
             return {"error": "Error retrieving disease severity statistics"}
 
 

--- a/pt_backend/repositories.py
+++ b/pt_backend/repositories.py
@@ -1,7 +1,7 @@
 from .models import Case, Disease, Location, News
 from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import Count, Case as DjangoCase, When, IntegerField, Sum
 from django.db.models import Count
-from .models import Case
 from .interfaces import CaseRepositoryInterface
 
 class DiseaseRepository:
@@ -16,39 +16,46 @@ class DiseaseRepository:
     
     def get_disease_severity_stats(self):
         try:
-            diseases = Disease.objects.prefetch_related('cases')
+            # Single efficient query with annotations
+            from django.db.models import Count, Case as DjangoCase, When, IntegerField, Sum
             
+            diseases = Disease.objects.annotate(
+                hospitalisasi_count=Sum(
+                    DjangoCase(
+                        When(cases__severity__iexact='hospitalisasi', then=1),
+                        default=0,
+                        output_field=IntegerField()
+                    )
+                ),
+                insiden_count=Sum(
+                    DjangoCase(
+                        When(cases__severity__iexact='insiden', then=1),
+                        default=0,
+                        output_field=IntegerField()
+                    )
+                ),
+                mortalitas_count=Sum(
+                    DjangoCase(
+                        When(cases__severity__iexact='mortalitas', then=1),
+                        default=0,
+                        output_field=IntegerField()
+                    )
+                ),
+                total_cases=Count('cases')
+            ).order_by('-total_cases')[:12]
+            
+            # Format the response
             result = []
             for disease in diseases:
-                # Initialize the disease info with only what's needed
                 disease_info = {
                     "name": disease.name,
-                    "severity_counts": {    
-                        "hospitalisasi": 0,
-                        "insiden": 0,
-                        "mortalitas": 0
+                    "severity_counts": {
+                        "hospitalisasi": disease.hospitalisasi_count or 0,
+                        "insiden": disease.insiden_count or 0,
+                        "mortalitas": disease.mortalitas_count or 0
                     },
-                    "total_cases": 0 
+                    "total_cases": disease.total_cases or 0
                 }
-                
-                severity_counts = disease.cases.values('severity').annotate(count=Count('id'))
-                
-                # Fill in the counts and calculate total
-                for item in severity_counts:
-                    severity = item['severity'].lower()  # Normalize to lowercase
-                    count = item['count']
-                    
-                    # Map any variations to standard keys
-                    if severity == "insiden":
-                        disease_info["severity_counts"]["insiden"] += count
-                    elif severity == "hospitalisasi":
-                        disease_info["severity_counts"]["hospitalisasi"] += count
-                    elif severity == "mortalitas":
-                        disease_info["severity_counts"]["mortalitas"] += count
-                    
-                    # Add to total regardless of severity type
-                    disease_info["total_cases"] += count
-                
                 result.append(disease_info)
                 
             return result

--- a/pt_backend/repositories.py
+++ b/pt_backend/repositories.py
@@ -17,11 +17,45 @@ class DiseaseRepository:
     def get_disease_severity_stats(self):
         try:
             diseases = Disease.objects.prefetch_related('cases')
+            
             result = []
+            for disease in diseases:
+                # Initialize the disease info with only what's needed
+                disease_info = {
+                    "name": disease.name,
+                    "severity_counts": {    
+                        "hospitalisasi": 0,
+                        "insiden": 0,
+                        "mortalitas": 0
+                    },
+                    "total_cases": 0 
+                }
+                
+                severity_counts = disease.cases.values('severity').annotate(count=Count('id'))
+                
+                # Fill in the counts and calculate total
+                for item in severity_counts:
+                    severity = item['severity'].lower()  # Normalize to lowercase
+                    count = item['count']
+                    
+                    # Map any variations to standard keys
+                    if severity == "insiden":
+                        disease_info["severity_counts"]["insiden"] += count
+                    elif severity == "hospitalisasi":
+                        disease_info["severity_counts"]["hospitalisasi"] += count
+                    elif severity == "mortalitas":
+                        disease_info["severity_counts"]["mortalitas"] += count
+                    
+                    # Add to total regardless of severity type
+                    disease_info["total_cases"] += count
+                
+                result.append(disease_info)
+                
             return result
         except Exception as e:
             print(f"Repository ERROR: {str(e)}")
             return {"error": "Error retrieving disease severity statistics"}
+
 
 class LocationRepository:
     def get_all_locations_name(self):

--- a/pt_backend/serializers.py
+++ b/pt_backend/serializers.py
@@ -6,3 +6,7 @@ class CaseLocationSerializer(serializers.Serializer):
     location__latitude = serializers.DecimalField(max_digits=8, decimal_places=6)
     city = serializers.CharField(max_length=255)
 
+class SeverityCountsSerializer(serializers.Serializer):
+
+
+class DiseaseSeverityStatsSerializer(serializers.Serializer):

--- a/pt_backend/serializers.py
+++ b/pt_backend/serializers.py
@@ -7,6 +7,11 @@ class CaseLocationSerializer(serializers.Serializer):
     city = serializers.CharField(max_length=255)
 
 class SeverityCountsSerializer(serializers.Serializer):
-
+    hospitalisasi = serializers.IntegerField()
+    insiden = serializers.IntegerField()
+    mortalitas = serializers.IntegerField()
 
 class DiseaseSeverityStatsSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    severity_counts = SeverityCountsSerializer()
+    total_cases = serializers.IntegerField()

--- a/pt_backend/services.py
+++ b/pt_backend/services.py
@@ -33,4 +33,8 @@ class DiseaseService:
         self.repository = repository or DiseaseRepository()
     
     def get_disease_severity_stats(self):
+        print("Service: Fetching disease severity stats")
+        result = self.repository.get_disease_severity_stats()
+        print(f"Service: Received result type: {type(result)}")
+        return result
         

--- a/pt_backend/services.py
+++ b/pt_backend/services.py
@@ -1,3 +1,4 @@
+from .repositories import DiseaseRepository
 from .interfaces import CaseRetrievalInterface, CaseRepositoryInterface, CacheInterface
 from django.core.cache import cache
 
@@ -26,3 +27,10 @@ class CacheService(CacheInterface):
 
     def delete(self, key):
         cache.delete(key)
+
+class DiseaseService:
+    def __init__(self, repository=None):
+        self.repository = repository or DiseaseRepository()
+    
+    def get_disease_severity_stats(self):
+        

--- a/pt_backend/services.py
+++ b/pt_backend/services.py
@@ -33,8 +33,5 @@ class DiseaseService:
         self.repository = repository or DiseaseRepository()
     
     def get_disease_severity_stats(self):
-        print("Service: Fetching disease severity stats")
         result = self.repository.get_disease_severity_stats()
-        print(f"Service: Received result type: {type(result)}")
         return result
-        

--- a/pt_backend/tests/rangkuman_penyakit/test_repository.py
+++ b/pt_backend/tests/rangkuman_penyakit/test_repository.py
@@ -1,0 +1,117 @@
+from django.test import TestCase
+from pt_backend.models import Disease, Case, Location
+from pt_backend.repositories import DiseaseRepository
+import uuid
+from unittest.mock import patch
+
+class DiseaseRepositoryTestCase(TestCase):
+    def setUp(self):
+        # Create test diseases
+        self.disease1 = Disease.objects.create(
+            id=uuid.uuid4(),
+            name="Test Disease 1",
+            level_of_alertness=3
+        )
+        self.disease2 = Disease.objects.create(
+            id=uuid.uuid4(),
+            name="Test Disease 2",
+            level_of_alertness=2
+        )
+        
+        # Create test locations
+        self.location1 = Location.objects.create(
+            id=uuid.uuid4(),
+            latitude=0.0,
+            longitude=0.0,
+            city="Test Location 1",
+            province="Test Province 1"
+        )
+        
+        # Create test cases with various severities
+        # Normal case with lowercase severity
+        Case.objects.create(
+            id=uuid.uuid4(),
+            gender="male",
+            age=30,
+            city="Test City",
+            status="minimal",
+            severity="hospitalisasi",
+            disease=self.disease1,
+            location=self.location1
+        )
+        
+        # Case with capitalized severity to test normalization
+        Case.objects.create(
+            id=uuid.uuid4(),
+            gender="female",
+            age=25,
+            city="Test City",
+            status="biasa",
+            severity="Insiden",
+            disease=self.disease1,
+            location=self.location1
+        )
+        
+        # Another case for same disease
+        Case.objects.create(
+            id=uuid.uuid4(),
+            gender="male",
+            age=40,
+            city="Test City",
+            status="bahaya",
+            severity="mortalitas",
+            disease=self.disease1,
+            location=self.location1
+        )
+        
+        # Case for second disease
+        Case.objects.create(
+            id=uuid.uuid4(),
+            gender="female",
+            age=35,
+            city="Test City",
+            status="katastropik",
+            severity="hospitalisasi",
+            disease=self.disease2,
+            location=self.location1
+        )
+        
+        self.repository = DiseaseRepository()
+
+    def test_get_disease_severity_stats(self):
+        """Test that disease severity stats are correctly calculated"""
+        results = self.repository.get_disease_severity_stats()
+        
+        # Check we got results for both diseases
+        self.assertEqual(len(results), 2)
+        
+        # Find each disease in results
+        disease1_result = next((r for r in results if r["name"] == "Test Disease 1"), None)
+        disease2_result = next((r for r in results if r["name"] == "Test Disease 2"), None)
+        
+        # Check disease1 stats
+        self.assertIsNotNone(disease1_result)
+        self.assertEqual(disease1_result["total_cases"], 3)
+        self.assertEqual(disease1_result["severity_counts"]["hospitalisasi"], 1)
+        self.assertEqual(disease1_result["severity_counts"]["insiden"], 1)  # Capitalized "Insiden" normalized
+        self.assertEqual(disease1_result["severity_counts"]["mortalitas"], 1)
+        
+        # Check disease2 stats
+        self.assertIsNotNone(disease2_result)
+        self.assertEqual(disease2_result["total_cases"], 1)
+        self.assertEqual(disease2_result["severity_counts"]["hospitalisasi"], 1)
+        self.assertEqual(disease2_result["severity_counts"]["insiden"], 0)
+        self.assertEqual(disease2_result["severity_counts"]["mortalitas"], 0)
+
+    def test_get_disease_severity_stats_error_handling(self):
+        """Test error handling in the repository method"""
+        # Patch Disease.objects.prefetch_related to raise an exception
+        with patch('pt_backend.models.Disease.objects.prefetch_related', 
+                side_effect=Exception("Test exception")):
+            result = self.repository.get_disease_severity_stats()
+            
+            # Check that we get an error dict back
+            self.assertIsNotNone(result)
+            self.assertIsInstance(result, dict)
+            self.assertIn("error", result)
+            self.assertEqual(result["error"], "Error retrieving disease severity statistics")

--- a/pt_backend/tests/rangkuman_penyakit/test_repository.py
+++ b/pt_backend/tests/rangkuman_penyakit/test_repository.py
@@ -85,33 +85,64 @@ class DiseaseRepositoryTestCase(TestCase):
         # Check we got results for both diseases
         self.assertEqual(len(results), 2)
         
-        # Find each disease in results
-        disease1_result = next((r for r in results if r["name"] == "Test Disease 1"), None)
-        disease2_result = next((r for r in results if r["name"] == "Test Disease 2"), None)
+        # First result should be the disease with most cases (disease1 with 3 cases)
+        self.assertEqual(results[0]["name"], "Test Disease 1")
+        self.assertEqual(results[0]["total_cases"], 3)
         
-        # Check disease1 stats
-        self.assertIsNotNone(disease1_result)
-        self.assertEqual(disease1_result["total_cases"], 3)
-        self.assertEqual(disease1_result["severity_counts"]["hospitalisasi"], 1)
-        self.assertEqual(disease1_result["severity_counts"]["insiden"], 1)  # Capitalized "Insiden" normalized
-        self.assertEqual(disease1_result["severity_counts"]["mortalitas"], 1)
+        # Second result should be disease2 with 1 case
+        self.assertEqual(results[1]["name"], "Test Disease 2")
+        self.assertEqual(results[1]["total_cases"], 1)
         
-        # Check disease2 stats
-        self.assertIsNotNone(disease2_result)
-        self.assertEqual(disease2_result["total_cases"], 1)
-        self.assertEqual(disease2_result["severity_counts"]["hospitalisasi"], 1)
-        self.assertEqual(disease2_result["severity_counts"]["insiden"], 0)
-        self.assertEqual(disease2_result["severity_counts"]["mortalitas"], 0)
+        # Check detailed counts for disease1
+        self.assertEqual(results[0]["severity_counts"]["hospitalisasi"], 1)
+        self.assertEqual(results[0]["severity_counts"]["insiden"], 1)
+        self.assertEqual(results[0]["severity_counts"]["mortalitas"], 1)
+        
+        # Check detailed counts for disease2
+        self.assertEqual(results[1]["severity_counts"]["hospitalisasi"], 1)
+        self.assertEqual(results[1]["severity_counts"]["insiden"], 0)
+        self.assertEqual(results[1]["severity_counts"]["mortalitas"], 0)
+
+    def test_get_disease_severity_stats_limit(self):
+        """Test that only top 12 diseases are returned"""
+        # Create 15 more diseases with 1 case each
+        for i in range(15):
+            disease = Disease.objects.create(
+                id=uuid.uuid4(),
+                name=f"Extra Disease {i}",
+                level_of_alertness=1
+            )
+            
+            Case.objects.create(
+                id=uuid.uuid4(),
+                gender="male",
+                age=30,
+                city="Test City",
+                status="minimal",
+                severity="hospitalisasi",
+                disease=disease,
+                location=self.location1
+            )
+        
+        # We should now have 17 diseases total (2 original + 15 new)
+        results = self.repository.get_disease_severity_stats()
+        
+        # Check that only 12 are returned
+        self.assertEqual(len(results), 12)
+        
+        # First result should still be disease1 with 3 cases
+        self.assertEqual(results[0]["name"], "Test Disease 1")
+        self.assertEqual(results[0]["total_cases"], 3)
 
     def test_get_disease_severity_stats_error_handling(self):
         """Test error handling in the repository method"""
-        # Patch Disease.objects.prefetch_related to raise an exception
-        with patch('pt_backend.models.Disease.objects.prefetch_related', 
+        # Update patch to match new implementation - patch annotate instead of prefetch_related
+        with patch('django.db.models.query.QuerySet.annotate', 
                 side_effect=Exception("Test exception")):
             result = self.repository.get_disease_severity_stats()
             
             # Check that we get an error dict back
             self.assertIsNotNone(result)
-            self.assertIsInstance(result, dict)
+            self.assertIsInstance(result, dict)  # Should be a dict, not a list
             self.assertIn("error", result)
             self.assertEqual(result["error"], "Error retrieving disease severity statistics")

--- a/pt_backend/tests/rangkuman_penyakit/test_serializer.py
+++ b/pt_backend/tests/rangkuman_penyakit/test_serializer.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+from pt_backend.serializers import DiseaseSeverityStatsSerializer, SeverityCountsSerializer
+
+class DiseaseSeverityStatsSerializerTestCase(TestCase):
+    def test_severity_counts_serializer(self):
+        """Test that SeverityCountsSerializer correctly serializes data"""
+        data = {
+            "hospitalisasi": 10,
+            "insiden": 5,
+            "mortalitas": 2
+        }
+        serializer = SeverityCountsSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data, data)
+    
+    def test_disease_severity_stats_serializer(self):
+        """Test that DiseaseSeverityStatsSerializer correctly serializes disease stats"""
+        data = {
+            "name": "Test Disease",
+            "severity_counts": {
+                "hospitalisasi": 10,
+                "insiden": 5,
+                "mortalitas": 2
+            },
+            "total_cases": 17
+        }
+        serializer = DiseaseSeverityStatsSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data["name"], "Test Disease")
+        self.assertEqual(serializer.validated_data["severity_counts"]["hospitalisasi"], 10)
+        self.assertEqual(serializer.validated_data["severity_counts"]["insiden"], 5)
+        self.assertEqual(serializer.validated_data["severity_counts"]["mortalitas"], 2)
+        self.assertEqual(serializer.validated_data["total_cases"], 17)

--- a/pt_backend/tests/rangkuman_penyakit/test_service.py
+++ b/pt_backend/tests/rangkuman_penyakit/test_service.py
@@ -1,0 +1,54 @@
+from django.test import TestCase
+from pt_backend.services import DiseaseService
+from unittest.mock import MagicMock, patch
+
+class DiseaseServiceTestCase(TestCase):
+    def setUp(self):
+        self.mock_repository = MagicMock()
+        self.service = DiseaseService(repository=self.mock_repository)
+        
+    def test_get_disease_severity_stats(self):
+        """Test that service passes the repository result"""
+        # Setup mock repository return value
+        expected_result = [
+            {
+                "name": "Test Disease",
+                "severity_counts": {
+                    "hospitalisasi": 1,
+                    "insiden": 2,
+                    "mortalitas": 3
+                },
+                "total_cases": 6
+            }
+        ]
+        self.mock_repository.get_disease_severity_stats.return_value = expected_result
+        
+        # Call the service method
+        result = self.service.get_disease_severity_stats()
+        
+        # Assert repository method was called
+        self.mock_repository.get_disease_severity_stats.assert_called_once()
+        
+        # Assert service returns repository result
+        self.assertEqual(result, expected_result)
+        
+    def test_get_disease_severity_stats_with_default_repository(self):
+        """Test that service works with default repository"""
+        with patch('pt_backend.services.DiseaseRepository') as mock_repo_class:
+            # Setup mock repository instance and class
+            mock_repo_instance = MagicMock()
+            mock_repo_class.return_value = mock_repo_instance
+            
+            expected_result = [{"name": "Test Disease"}]
+            mock_repo_instance.get_disease_severity_stats.return_value = expected_result
+            
+            # Create service with default repository
+            service = DiseaseService()
+            result = service.get_disease_severity_stats()
+            
+            # Assert default repository was used
+            mock_repo_class.assert_called_once()
+            mock_repo_instance.get_disease_severity_stats.assert_called_once()
+            
+            # Assert result is as expected
+            self.assertEqual(result, expected_result)

--- a/pt_backend/tests/rangkuman_penyakit/test_url.py
+++ b/pt_backend/tests/rangkuman_penyakit/test_url.py
@@ -1,0 +1,12 @@
+from django.test import TestCase
+from django.urls import reverse, resolve
+from pt_backend.views import DiseaseSeverityStatsView
+
+class URLsTestCase(TestCase):
+    def test_disease_severity_stats_url(self):
+        """Test the disease severity stats URL works correctly"""
+        url = reverse('disease-severity-stats')
+        self.assertEqual(url, '/api/diseases/severity-stats/')
+        
+        resolver = resolve('/api/diseases/severity-stats/')
+        self.assertEqual(resolver.func.view_class, DiseaseSeverityStatsView)

--- a/pt_backend/tests/rangkuman_penyakit/test_view.py
+++ b/pt_backend/tests/rangkuman_penyakit/test_view.py
@@ -1,0 +1,107 @@
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory, force_authenticate
+from pt_backend.views import DiseaseSeverityStatsView
+from unittest.mock import MagicMock, patch
+from pt_backend.authentication import APIKeyAuthentication
+
+class DiseaseSeverityStatsViewTestCase(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.view = DiseaseSeverityStatsView.as_view()
+        
+    @patch('pt_backend.views.DiseaseService')
+    @patch('pt_backend.authentication.APIKeyAuthentication.authenticate')
+    def test_get_disease_severity_stats_success(self, mock_auth, mock_service_class):
+        """Test successful retrieval of disease severity stats"""
+        # Setup authentication bypass
+        mock_auth.return_value = (None, None)
+        
+        # Setup mock service
+        mock_service_instance = MagicMock()
+        mock_service_class.return_value = mock_service_instance
+        
+        # Setup mock service response
+        mock_service_instance.get_disease_severity_stats.return_value = [
+            {
+                "name": "Test Disease 1",
+                "severity_counts": {
+                    "hospitalisasi": 1,
+                    "insiden": 2,
+                    "mortalitas": 3
+                },
+                "total_cases": 6
+            },
+            {
+                "name": "Test Disease 2",
+                "severity_counts": {
+                    "hospitalisasi": 4,
+                    "insiden": 5,
+                    "mortalitas": 6
+                },
+                "total_cases": 15
+            }
+        ]
+        
+        # Make request
+        request = self.factory.get('/api/diseases/severity-stats/')
+        response = self.view(request)
+        
+        # Verify response
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('data', response.data)
+        self.assertEqual(len(response.data['data']), 2)
+        
+        disease1 = response.data['data'][0]
+        self.assertEqual(disease1['name'], "Test Disease 1")
+        self.assertEqual(disease1['total_cases'], 6)
+        self.assertEqual(disease1['severity_counts']['hospitalisasi'], 1)
+        self.assertEqual(disease1['severity_counts']['insiden'], 2)
+        self.assertEqual(disease1['severity_counts']['mortalitas'], 3)
+        
+    @patch('pt_backend.views.DiseaseService')
+    @patch('pt_backend.authentication.APIKeyAuthentication.authenticate')
+    def test_get_disease_severity_stats_error(self, mock_auth, mock_service_class):
+        """Test error handling in view when service returns error"""
+        # Setup authentication bypass
+        mock_auth.return_value = (None, None)
+        
+        # Setup mock service
+        mock_service_instance = MagicMock()
+        mock_service_class.return_value = mock_service_instance
+        
+        # Setup mock service to return an error dict
+        mock_service_instance.get_disease_severity_stats.return_value = {
+            "error": "Test error message"
+        }
+        
+        # Make request
+        request = self.factory.get('/api/diseases/severity-stats/')
+        response = self.view(request)
+        
+        # Verify error response
+        self.assertEqual(response.status_code, 500)
+        self.assertIn('error', response.data)
+        self.assertEqual(response.data['error'], "Test error message")
+        
+    @patch('pt_backend.views.DiseaseService')
+    @patch('pt_backend.authentication.APIKeyAuthentication.authenticate')
+    def test_get_disease_severity_stats_exception(self, mock_auth, mock_service_class):
+        """Test exception handling in view when service raises exception"""
+        # Setup authentication bypass
+        mock_auth.return_value = (None, None)
+        
+        # Setup mock service
+        mock_service_instance = MagicMock()
+        mock_service_class.return_value = mock_service_instance
+        
+        # Setup mock service to raise exception
+        mock_service_instance.get_disease_severity_stats.side_effect = Exception("Test exception")
+        
+        # Make request
+        request = self.factory.get('/api/diseases/severity-stats/')
+        response = self.view(request)
+        
+        # Verify error response
+        self.assertEqual(response.status_code, 500)
+        self.assertIn('error', response.data)
+        self.assertEqual(response.data['error'], "An unexpected error occurred. Please try again later.")

--- a/pt_backend/urls.py
+++ b/pt_backend/urls.py
@@ -4,4 +4,5 @@ from .views import AllCaseLocationsView, FiltersView, DiseaseSeverityStatsView
 urlpatterns = [
     path('cases/locations/', AllCaseLocationsView.as_view(), name='all-case-locations'),
     path('api/filters/', FiltersView.as_view(), name='filters'),
+    path('api/diseases/severity-stats/', DiseaseSeverityStatsView.as_view(), name='disease-severity-stats'),
 ]

--- a/pt_backend/urls.py
+++ b/pt_backend/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import AllCaseLocationsView, FiltersView
+from .views import AllCaseLocationsView, FiltersView, DiseaseSeverityStatsView
 
 urlpatterns = [
     path('cases/locations/', AllCaseLocationsView.as_view(), name='all-case-locations'),

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -7,7 +7,6 @@ from .filter.service import CaseFilterService
 from .repositories import CaseRepository, DiseaseRepository, LocationRepository, NewsRepository
 from .authentication import APIKeyAuthentication
 
-
 class AllCaseLocationsView(APIView):
     authentication_classes = [APIKeyAuthentication]
     permission_classes = []
@@ -29,7 +28,6 @@ class AllCaseLocationsView(APIView):
             serialized_data = self.serializer_class(cases, many=True).data
             return Response(serialized_data, status=status.HTTP_200_OK)
         except Exception as e:
-            print(e)
             return Response({"error": "An unexpected error occurred. Please try again later."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def post(self, request):
@@ -101,7 +99,6 @@ class DiseaseSeverityStatsView(APIView):
             }, status=status.HTTP_200_OK)
             
         except Exception as e:
-            print(f"ERROR: {str(e)}")
             return Response(
                 {"error": "An unexpected error occurred. Please try again later."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -7,6 +7,8 @@ from .filter.service import CaseFilterService
 from .repositories import CaseRepository, DiseaseRepository, LocationRepository, NewsRepository
 from .authentication import APIKeyAuthentication
 
+INTERNAL_SERVER_ERR_MSG = "An unexpected error occurred. Please try again later."
+
 class AllCaseLocationsView(APIView):
     authentication_classes = [APIKeyAuthentication]
     permission_classes = []
@@ -27,8 +29,8 @@ class AllCaseLocationsView(APIView):
                 return Response({"error": "No case locations found"}, status=status.HTTP_404_NOT_FOUND)
             serialized_data = self.serializer_class(cases, many=True).data
             return Response(serialized_data, status=status.HTTP_200_OK)
-        except Exception as e:
-            return Response({"error": "An unexpected error occurred. Please try again later."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except Exception:
+            return Response({"error": INTERNAL_SERVER_ERR_MSG}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def post(self, request):
         try:
@@ -48,9 +50,9 @@ class AllCaseLocationsView(APIView):
                 self.serializer_class(cases, many=True).data,
                 status=status.HTTP_200_OK
             )
-        except Exception as e:
+        except Exception:
             return Response(
-                {"error": "An unexpected error occurred. Please try again later."},
+                {"error": INTERNAL_SERVER_ERR_MSG},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
 
@@ -98,8 +100,8 @@ class DiseaseSeverityStatsView(APIView):
                 "data": serialized_data
             }, status=status.HTTP_200_OK)
             
-        except Exception as e:
+        except Exception:
             return Response(
-                {"error": "An unexpected error occurred. Please try again later."},
+                {"error": INTERNAL_SERVER_ERR_MSG},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -1,8 +1,8 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
-from .serializers import CaseLocationSerializer
-from .services import CacheService, CaseService
+from .serializers import CaseLocationSerializer, DiseaseSeverityStatsSerializer
+from .services import CacheService, CaseService, DiseaseService
 from .filter.service import CaseFilterService
 from .repositories import CaseRepository, DiseaseRepository, LocationRepository, NewsRepository
 from .authentication import APIKeyAuthentication
@@ -56,8 +56,6 @@ class AllCaseLocationsView(APIView):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
 
-
-
 class FiltersView(APIView):
     def get(self, request):
         disease_repository = DiseaseRepository()
@@ -79,3 +77,19 @@ class FiltersView(APIView):
             return Response(response_data, status=status.HTTP_200_OK)
         except Exception as e:
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        
+class DiseaseSeverityStatsView(APIView):
+    authentication_classes = [APIKeyAuthentication]
+    permission_classes = []
+    
+    serializer_class = DiseaseSeverityStatsSerializer
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.service = DiseaseService()
+    
+    def get(self, request):
+        try:
+            stats = self.service.get_disease_severity_stats()
+        except Exception as e:
+            

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -91,5 +91,18 @@ class DiseaseSeverityStatsView(APIView):
     def get(self, request):
         try:
             stats = self.service.get_disease_severity_stats()
-        except Exception as e:
             
+            if isinstance(stats, dict) and "error" in stats:
+                return Response(stats, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            
+            serialized_data = self.serializer_class(stats, many=True).data
+            return Response({
+                "data": serialized_data
+            }, status=status.HTTP_200_OK)
+            
+        except Exception as e:
+            print(f"ERROR: {str(e)}")
+            return Response(
+                {"error": "An unexpected error occurred. Please try again later."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )


### PR DESCRIPTION
# Summary

This pull request adds a new endpoint, namely `get_disease_severity`, this endpoint will be used to obtain data on the top 12 diseases with the highest number of cases which will be displayed by the front end component.

# Changes

- Create new repository method `get_disease_severity_stats` for retrieving disease severity stats
- Create new `DiseaseService` class and `get_disease_severity_stats` in service layer to retrieve disease severity from repository
- Create new `DiseaseSeverityStatsView` and it's `url` to mapping the endpoint
- Create unit test for the new addition endpoint
- Implement error handling for the severity disease endpoint, returning appropriate HTTP status codes

# How to Test

## Run Server

```
python manage.py runserver
```

## Access Endpoint

This endpoint use `API-Key` for authentication so make sure you included the `API-Key` in the header request. The endpoint can be accessed by hiting the endpoint: `/api/diseases/severity-stats/`. The data should return with the following format:
```
"data": [
    {
      "name": "Malaria",
      "severity_counts": {
        "hospitalisasi": 2,
        "insiden": 2,
        "mortalitas": 0
      },
      "total_cases": 4
    },
    {
      "name": "HIV",
      "severity_counts": {
        "hospitalisasi": 0,
        "insiden": 3,
        "mortalitas": 0
      },
      "total_cases": 3
    },
. . .
```

## Further Development
- Using caching to reduce response time
- Integrating with other services
