### PR TITLE
[PBI A03] Email checker v2

### DIFF
--- a/authentication/email_services.py
+++ b/authentication/email_services.py
@@ -1,0 +1,41 @@
+from abc import ABC, abstractmethod
+import os
+
+import sib_api_v3_sdk
+from sib_api_v3_sdk.rest import ApiException
+from sib_api_v3_sdk import TransactionalEmailsApi, ApiClient, SendSmtpEmail
+from django.core.mail import send_mail
+
+class EmailService(ABC):
+    @abstractmethod
+    def send_password_reset_email(self, recipient_email, reset_link):
+        """Send an email with the reset link."""
+        pass
+
+class BrevoEmailService(EmailService):
+    """Brevo-specific email service implementation"""
+    
+    def __init__(self, api_key=None, sender_name="PPL BRIN", sender_email="pplbrin02@gmail.com"):
+        self.api_key = api_key or os.getenv("BREVO_API_KEY")
+        self.sender = {"name": sender_name, "email": sender_email}
+    
+    def send_password_reset_email(self, recipient_email, reset_link, template_id=1):
+        configuration = sib_api_v3_sdk.Configuration()
+        configuration.api_key['api-key'] = self.api_key
+        api_instance = TransactionalEmailsApi(ApiClient(configuration))
+        
+        recipients = [{"email": recipient_email}]
+        params = {"reset_link": reset_link}
+
+        send_smtp_email = SendSmtpEmail(
+            to=recipients,
+            sender=self.sender,
+            template_id=template_id,
+            params=params
+        )
+
+        try:
+            return api_instance.send_transac_email(send_smtp_email)
+        except ApiException as e:
+            print(f"Exception when calling TransactionalEmailsApi: {e}")
+            raise

--- a/authentication/services.py
+++ b/authentication/services.py
@@ -69,7 +69,6 @@ class PasswordResetService:
         params = {
             "reset_link": reset_link
         }
-        template_id = template_id
 
         send_smtp_email = SendSmtpEmail(
             to=recipients,

--- a/authentication/services.py
+++ b/authentication/services.py
@@ -1,19 +1,18 @@
 from django.contrib.auth.tokens import default_token_generator
-from django.core.mail import send_mail
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.utils.encoding import force_bytes
 from pt_backend.models import User
-import sib_api_v3_sdk
-from sib_api_v3_sdk.rest import ApiException
-from sib_api_v3_sdk import TransactionalEmailsApi, ApiClient, SendSmtpEmail
+from authentication.email_services import BrevoEmailService
 
 import os
 
 class PasswordResetService:
-    def __init__(self, reset_url_base=None):
+    def __init__(self, reset_url_base=None, email_service=None):
         self.reset_url_base = reset_url_base or os.getenv(
             'PROD_PASSWORD_RESET_URL') or os.getenv(
             'DEV_PASSWORD_RESET_URL')
+        
+        self.email_service = email_service or BrevoEmailService()
     
     def find_user_by_email(self, email):
         return User.objects.get(email=email) if User.objects.filter(email=email).exists() else None
@@ -26,20 +25,11 @@ class PasswordResetService:
     def create_password_reset_link(self, uid, token):
         return f"{self.reset_url_base}?uid={uid}&token={token}"
     
-    def send_password_reset_email(self, email, reset_link):
-        send_mail(
-            subject="Reset Password Akunmu",
-            message=f"Klik link berikut untuk mereset password akunmu: {reset_link}",
-            from_email="cyrilus2004@gmail.com",
-            recipient_list=[email],
-            fail_silently=False,
-        )
-    
     def process_reset_request(self, email):
         user = self.find_user_by_email(email)
         uid, token = self.generate_password_reset_token(user)
         reset_link = self.create_password_reset_link(uid, token)
-        self.send_brevo_email(reset_link, email)
+        self.email_service.send_password_reset_email(email, reset_link)
         return True
     
     def get_user_from_uidb64(self, uidb64):
@@ -56,30 +46,3 @@ class PasswordResetService:
         if not user:
             return False
         return default_token_generator.check_token(user, token)
-
-    def send_brevo_email(self, reset_link, email, template_id=1):
-        """
-        Send an email using Brevo service.
-        """
-        configuration = sib_api_v3_sdk.Configuration()
-        configuration.api_key['api-key'] = os.getenv("BREVO_API_KEY")
-        api_instance = TransactionalEmailsApi(ApiClient(configuration))
-        sender = {"name": "PPL BRIN", "email": "pplbrin02@gmail.com"}
-        recipients = [{"email": email}]
-        params = {
-            "reset_link": reset_link
-        }
-
-        send_smtp_email = SendSmtpEmail(
-            to=recipients,
-            sender=sender,
-            template_id=template_id,
-            params=params
-        )
-
-        try:
-            api_response = api_instance.send_transac_email(send_smtp_email)
-            print("Email sent successfully!")
-            print(api_response)
-        except ApiException as e:
-            print("Exception when calling TransactionalEmailsApi->send_transac_email: %s\n" % e)

--- a/authentication/services.py
+++ b/authentication/services.py
@@ -39,7 +39,6 @@ class PasswordResetService:
         user = self.find_user_by_email(email)
         uid, token = self.generate_password_reset_token(user)
         reset_link = self.create_password_reset_link(uid, token)
-        self.send_password_reset_email(email, reset_link)
         self.send_brevo_email(reset_link, email)
         return True
     

--- a/authentication/services.py
+++ b/authentication/services.py
@@ -3,6 +3,9 @@ from django.core.mail import send_mail
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.utils.encoding import force_bytes
 from pt_backend.models import User
+import sib_api_v3_sdk
+from sib_api_v3_sdk.rest import ApiException
+from sib_api_v3_sdk import TransactionalEmailsApi, ApiClient, SendSmtpEmail
 
 import os
 
@@ -27,7 +30,7 @@ class PasswordResetService:
         send_mail(
             subject="Reset Password Akunmu",
             message=f"Klik link berikut untuk mereset password akunmu: {reset_link}",
-            from_email="no-reply@gmail.com",
+            from_email="cyrilus2004@gmail.com",
             recipient_list=[email],
             fail_silently=False,
         )
@@ -37,6 +40,7 @@ class PasswordResetService:
         uid, token = self.generate_password_reset_token(user)
         reset_link = self.create_password_reset_link(uid, token)
         self.send_password_reset_email(email, reset_link)
+        self.send_brevo_email(reset_link, email)
         return True
     
     def get_user_from_uidb64(self, uidb64):
@@ -53,3 +57,9 @@ class PasswordResetService:
         if not user:
             return False
         return default_token_generator.check_token(user, token)
+
+    def send_brevo_email(self, reset_link, email, template_id=1):
+        """
+        Send an email using Brevo service.
+        """
+        configuration = sib_api_v3_sdk.Configuration()

--- a/authentication/services.py
+++ b/authentication/services.py
@@ -24,7 +24,7 @@ class PasswordResetService:
         return uid, token
 
     def create_password_reset_link(self, uid, token):
-        return f"{self.reset_url_base}/{uid}/{token}"
+        return f"{self.reset_url_base}?uid={uid}&token={token}"
     
     def send_password_reset_email(self, email, reset_link):
         send_mail(

--- a/authentication/services.py
+++ b/authentication/services.py
@@ -63,3 +63,25 @@ class PasswordResetService:
         Send an email using Brevo service.
         """
         configuration = sib_api_v3_sdk.Configuration()
+        configuration.api_key['api-key'] = os.getenv("BREVO_API_KEY")
+        api_instance = TransactionalEmailsApi(ApiClient(configuration))
+        sender = {"name": "PPL BRIN", "email": "pplbrin02@gmail.com"}
+        recipients = [{"email": email}]
+        params = {
+            "reset_link": reset_link
+        }
+        template_id = template_id
+
+        send_smtp_email = SendSmtpEmail(
+            to=recipients,
+            sender=sender,
+            template_id=template_id,
+            params=params
+        )
+
+        try:
+            api_response = api_instance.send_transac_email(send_smtp_email)
+            print("Email sent successfully!")
+            print(api_response)
+        except ApiException as e:
+            print("Exception when calling TransactionalEmailsApi->send_transac_email: %s\n" % e)

--- a/authentication/tests/forgot_password/mock_email_service.py
+++ b/authentication/tests/forgot_password/mock_email_service.py
@@ -1,0 +1,16 @@
+from authentication.email_services import EmailService
+
+class MockEmailService(EmailService):
+    """Mock email service for testing"""
+    
+    def __init__(self):
+        self.sent_emails = []
+    
+    def send_password_reset_email(self, recipient_email, reset_link, template_id=None):
+        """Record emails instead of sending them"""
+        self.sent_emails.append({
+            "recipient": recipient_email,
+            "reset_link": reset_link,
+            "template_id": template_id
+        })
+        return True

--- a/authentication/tests/forgot_password/test_email_service.py
+++ b/authentication/tests/forgot_password/test_email_service.py
@@ -1,0 +1,41 @@
+from django.test import TestCase
+from unittest.mock import patch
+from authentication.email_services import (
+    BrevoEmailService, 
+)
+from authentication.tests.forgot_password.mock_email_service import MockEmailService
+
+class TestEmailServices(TestCase):
+    """Test cases for all email service implementations"""
+    
+    def test_mock_email_service(self):
+        """Test that mock email service records emails properly"""
+        service = MockEmailService()
+        
+        service.send_password_reset_email("test@example.com", "https://reset.link", 2)
+        
+        self.assertEqual(len(service.sent_emails), 1)
+        self.assertEqual(service.sent_emails[0]["recipient"], "test@example.com")
+        self.assertEqual(service.sent_emails[0]["reset_link"], "https://reset.link")
+        self.assertEqual(service.sent_emails[0]["template_id"], 2)
+    
+    @patch('authentication.email_services.TransactionalEmailsApi')
+    @patch('authentication.email_services.ApiClient')
+    @patch('authentication.email_services.os.getenv')
+    def test_brevo_email_service(self, mock_getenv, mock_api_client, mock_transactional_api):
+        """Test Brevo email service implementation"""
+        mock_getenv.return_value = "mock-api-key"
+        mock_api_instance = mock_transactional_api.return_value
+        
+        service = BrevoEmailService(sender_name="Test Sender", sender_email="test@sender.com")
+        
+        service.send_password_reset_email("recipient@example.com", "https://reset.link", 3)
+        
+        mock_api_instance.send_transac_email.assert_called_once()
+        
+        send_email_call = mock_api_instance.send_transac_email.call_args[0][0]
+        self.assertEqual(send_email_call.to[0]["email"], "recipient@example.com")
+        self.assertEqual(send_email_call.sender["name"], "Test Sender")
+        self.assertEqual(send_email_call.sender["email"], "test@sender.com")
+        self.assertEqual(send_email_call.template_id, 3)
+        self.assertEqual(send_email_call.params["reset_link"], "https://reset.link")

--- a/authentication/tests/forgot_password/test_services.py
+++ b/authentication/tests/forgot_password/test_services.py
@@ -6,6 +6,8 @@ from authentication.services import PasswordResetService
 from django.contrib.auth.tokens import default_token_generator
 from pt_backend.models import User
 
+from sib_api_v3_sdk.rest import ApiException
+
 class TestPasswordResetService(TestCase):
     def setUp(self):
         self.user = User.objects.create(
@@ -147,3 +149,91 @@ class TestPasswordResetService(TestCase):
         token = ""
         result = self.service.validate_token(self.user, token)
         self.assertFalse(result)
+
+    @patch('authentication.services.TransactionalEmailsApi')
+    @patch('authentication.services.ApiClient')
+    @patch('authentication.services.os.getenv')
+    def test_send_brevo_email_successful(self, mock_getenv, mock_api_client, mock_transactional_api):
+        """Test successful sending of email via Brevo"""
+        mock_getenv.return_value = "mock-api-key"
+        mock_api_instance = mock_transactional_api.return_value
+        mock_api_instance.send_transac_email.return_value = {"message_id": "test-id"}
+        
+        reset_link = "https://example.com/reset/abc123/def456"
+        email = "user@example.com"
+        self.service.send_brevo_email(reset_link, email)
+        
+        mock_api_instance.send_transac_email.assert_called_once()
+        
+        send_email_call = mock_api_instance.send_transac_email.call_args[0][0]
+        self.assertEqual(send_email_call.to[0]["email"], email)
+        self.assertEqual(send_email_call.sender["name"], "PPL BRIN")
+        self.assertEqual(send_email_call.template_id, 1)  # Default template_id
+        self.assertEqual(send_email_call.params["reset_link"], reset_link)
+
+    @patch('authentication.services.TransactionalEmailsApi')
+    @patch('authentication.services.ApiClient')
+    @patch('authentication.services.os.getenv')
+    def test_send_brevo_email_custom_template(self, mock_getenv, mock_api_client, mock_transactional_api):
+        """Test sending email with custom template ID"""
+        mock_getenv.return_value = "mock-api-key"
+        mock_api_instance = mock_transactional_api.return_value
+        
+        custom_template_id = 5
+        self.service.send_brevo_email("https://example.com/reset", "user@example.com", custom_template_id)
+        
+        send_email_call = mock_api_instance.send_transac_email.call_args[0][0]
+        self.assertEqual(send_email_call.template_id, custom_template_id)
+
+    @patch('authentication.services.TransactionalEmailsApi')
+    @patch('authentication.services.ApiClient')
+    @patch('authentication.services.os.getenv')
+    @patch('builtins.print')
+    def test_send_brevo_email_api_exception(self, mock_print, mock_getenv, mock_api_client, mock_transactional_api):
+        """Test handling of API exception when sending email"""
+        mock_getenv.return_value = "mock-api-key"
+        mock_api_instance = mock_transactional_api.return_value
+        mock_api_instance.send_transac_email.side_effect = ApiException(reason="API Error")
+        
+        self.service.send_brevo_email("https://example.com/reset", "user@example.com")
+        
+        mock_print.assert_any_call("Exception when calling TransactionalEmailsApi->send_transac_email: %s\n" % mock_api_instance.send_transac_email.side_effect)
+
+    @patch('authentication.services.TransactionalEmailsApi')
+    @patch('authentication.services.ApiClient')
+    @patch('authentication.services.os.getenv')
+    def test_send_brevo_email_missing_api_key(self, mock_getenv, mock_api_client, mock_transactional_api):
+        """Test behavior when API key is missing"""
+        mock_getenv.return_value = None
+        
+        self.service.send_brevo_email("https://example.com/reset", "user@example.com")
+        
+        mock_api_client.assert_called_once()
+        config = mock_api_client.call_args[0][0]
+        self.assertIsNone(config.api_key.get('api-key'))
+
+    @patch('authentication.services.PasswordResetService.send_brevo_email')
+    def test_process_reset_request_uses_brevo(self, mock_send_brevo):
+        """Test that process_reset_request uses send_brevo_email"""
+        mock_send_brevo.return_value = None
+        
+        self.service.process_reset_request('test@example.com')
+        
+        mock_send_brevo.assert_called_once()
+        args = mock_send_brevo.call_args[0]
+        self.assertTrue(len(args) >= 2) 
+        self.assertEqual(args[1], 'test@example.com')  
+
+    @patch('authentication.services.TransactionalEmailsApi')
+    @patch('authentication.services.ApiClient')
+    @patch('authentication.services.os.getenv')
+    def test_send_brevo_email_special_chars(self, mock_getenv, mock_api_client, mock_transactional_api):
+        """Test sending email with special characters in reset link"""
+        mock_getenv.return_value = "mock-api-key"
+        mock_api_instance = mock_transactional_api.return_value
+        
+        special_link = "https://example.com/reset?token=abc&id=123#section"
+        self.service.send_brevo_email(special_link, "user@example.com")
+        
+        send_email_call = mock_api_instance.send_transac_email.call_args[0][0]
+        self.assertEqual(send_email_call.params["reset_link"], special_link)

--- a/authentication/tests/forgot_password/test_services.py
+++ b/authentication/tests/forgot_password/test_services.py
@@ -134,7 +134,7 @@ class TestPasswordResetService(TestCase):
             service.process_reset_request('test@example.com')
             
             mock_send.assert_called_once()
-            args, kwargs = mock_send.call_args
+            args, _ = mock_send.call_args
             self.assertEqual(args[0], 'test@example.com')
     
     def test_password_reset_service_with_brevo_email(self):

--- a/authentication/tests/forgot_password/test_services.py
+++ b/authentication/tests/forgot_password/test_services.py
@@ -36,9 +36,14 @@ class TestPasswordResetService(TestCase):
         """Test that reset link creation works properly"""
         uid, token = self.service.generate_password_reset_token(self.user)
         link = self.service.create_password_reset_link(uid, token)
+        
         self.assertTrue(link.startswith("http://localhost:3000/forgot-password/reset"))
-        self.assertTrue(uid in link)
-        self.assertTrue(token in link)
+        
+        self.assertTrue(f"?uid={uid}" in link)
+        self.assertTrue(f"&token={token}" in link)
+        
+        expected_format = f"{self.service.reset_url_base}?uid={uid}&token={token}"
+        self.assertEqual(link, expected_format)
         
     @patch('authentication.services.send_mail')
     def test_send_reset_email_successful(self, mock_send_mail):

--- a/authentication/tests/forgot_password/test_services.py
+++ b/authentication/tests/forgot_password/test_services.py
@@ -50,13 +50,6 @@ class TestPasswordResetService(TestCase):
         """Test that email sending works properly"""
         self.service.send_password_reset_email('test@example.com', 'https://test.link')
         mock_send_mail.assert_called_once()
-        
-    @patch('authentication.services.PasswordResetService.send_password_reset_email')
-    def test_process_reset_request_successful(self, mock_send_email):
-        """Test the complete reset request flow"""
-        result = self.service.process_reset_request('test@example.com')
-        self.assertTrue(result)
-        mock_send_email.assert_called_once()
     
     def test_find_nonexistent_user(self):
         """Test finding a user that doesn't exist"""
@@ -66,7 +59,7 @@ class TestPasswordResetService(TestCase):
     @patch('authentication.services.PasswordResetService.send_password_reset_email')
     def test_process_reset_nonexistent_user(self, mock_send_email):
         """Test processing reset with non-existent user"""
-        with self.assertRaises(AttributeError):  # Since user will be None
+        with self.assertRaises(AttributeError): 
             self.service.process_reset_request('nonexistent@example.com')
         
     @patch('authentication.services.send_mail')

--- a/authentication/tests/forgot_password/test_services.py
+++ b/authentication/tests/forgot_password/test_services.py
@@ -5,7 +5,8 @@ from unittest.mock import patch, MagicMock
 from authentication.services import PasswordResetService
 from django.contrib.auth.tokens import default_token_generator
 from pt_backend.models import User
-
+from authentication.tests.forgot_password.mock_email_service import MockEmailService
+from authentication.email_services import BrevoEmailService
 from sib_api_v3_sdk.rest import ApiException
 
 class TestPasswordResetService(TestCase):
@@ -26,10 +27,8 @@ class TestPasswordResetService(TestCase):
     def test_generate_token_successful(self):
         """Test that token generation produces valid uid and token"""
         uid, token = self.service.generate_password_reset_token(self.user)
-        # Verify uid decodes to the user's id
         decoded_uid = urlsafe_base64_decode(uid).decode()
         self.assertEqual(int(decoded_uid), self.user.id)
-        # Token should be a non-empty string
         self.assertTrue(token and isinstance(token, str))
         
     def test_create_reset_link_successful(self):
@@ -45,30 +44,11 @@ class TestPasswordResetService(TestCase):
         expected_format = f"{self.service.reset_url_base}?uid={uid}&token={token}"
         self.assertEqual(link, expected_format)
         
-    @patch('authentication.services.send_mail')
-    def test_send_reset_email_successful(self, mock_send_mail):
-        """Test that email sending works properly"""
-        self.service.send_password_reset_email('test@example.com', 'https://test.link')
-        mock_send_mail.assert_called_once()
-    
     def test_find_nonexistent_user(self):
         """Test finding a user that doesn't exist"""
         user = self.service.find_user_by_email('nonexistent@example.com')
         self.assertIsNone(user)
         
-    @patch('authentication.services.PasswordResetService.send_password_reset_email')
-    def test_process_reset_nonexistent_user(self, mock_send_email):
-        """Test processing reset with non-existent user"""
-        with self.assertRaises(AttributeError): 
-            self.service.process_reset_request('nonexistent@example.com')
-        
-    @patch('authentication.services.send_mail')
-    def test_send_email_error(self, mock_send_mail):
-        """Test handling email sending error"""
-        mock_send_mail.side_effect = Exception("Email error")
-        with self.assertRaises(Exception):
-            self.service.send_password_reset_email('test@example.com', 'https://test.link')
-            
     def test_generate_token_invalid_user(self):
         """Test token generation with invalid user"""
         invalid_user = MagicMock()
@@ -80,19 +60,6 @@ class TestPasswordResetService(TestCase):
         """Test handling empty email"""
         user = self.service.find_user_by_email('')
         self.assertIsNone(user)
-        
-    @patch('authentication.services.send_mail')
-    def test_unicode_email(self, mock_send_mail):
-        """Test handling email with unicode characters"""
-        User.objects.create(
-            email='tëst@exämple.com',
-            name='unicodeuser',
-            password='password123',
-            role="TEST ROLE"
-        )
-        
-        self.service.send_password_reset_email('tëst@exämple.com', 'https://test.link')
-        mock_send_mail.assert_called_once()
         
     def test_special_chars_in_url(self):
         """Test handling special characters in URL base"""
@@ -148,90 +115,51 @@ class TestPasswordResetService(TestCase):
         result = self.service.validate_token(self.user, token)
         self.assertFalse(result)
 
-    @patch('authentication.services.TransactionalEmailsApi')
-    @patch('authentication.services.ApiClient')
-    @patch('authentication.services.os.getenv')
-    def test_send_brevo_email_successful(self, mock_getenv, mock_api_client, mock_transactional_api):
-        """Test successful sending of email via Brevo"""
-        mock_getenv.return_value = "mock-api-key"
-        mock_api_instance = mock_transactional_api.return_value
-        mock_api_instance.send_transac_email.return_value = {"message_id": "test-id"}
+    def test_password_reset_service_with_mock_email(self):
+        """Test PasswordResetService with a mock email service"""
         
-        reset_link = "https://example.com/reset/abc123/def456"
-        email = "user@example.com"
-        self.service.send_brevo_email(reset_link, email)
+        mock_email_service = MockEmailService()
+        service = PasswordResetService(email_service=mock_email_service)
         
-        mock_api_instance.send_transac_email.assert_called_once()
+        service.process_reset_request('test@example.com')
         
-        send_email_call = mock_api_instance.send_transac_email.call_args[0][0]
-        self.assertEqual(send_email_call.to[0]["email"], email)
-        self.assertEqual(send_email_call.sender["name"], "PPL BRIN")
-        self.assertEqual(send_email_call.template_id, 1)  # Default template_id
-        self.assertEqual(send_email_call.params["reset_link"], reset_link)
+        self.assertEqual(len(mock_email_service.sent_emails), 1)
+        self.assertEqual(mock_email_service.sent_emails[0]["recipient"], 'test@example.com')
 
-    @patch('authentication.services.TransactionalEmailsApi')
-    @patch('authentication.services.ApiClient')
-    @patch('authentication.services.os.getenv')
-    def test_send_brevo_email_custom_template(self, mock_getenv, mock_api_client, mock_transactional_api):
-        """Test sending email with custom template ID"""
-        mock_getenv.return_value = "mock-api-key"
-        mock_api_instance = mock_transactional_api.return_value
-        
-        custom_template_id = 5
-        self.service.send_brevo_email("https://example.com/reset", "user@example.com", custom_template_id)
-        
-        send_email_call = mock_api_instance.send_transac_email.call_args[0][0]
-        self.assertEqual(send_email_call.template_id, custom_template_id)
+    def test_password_reset_service_default_email_service(self):
+        """Test that PasswordResetService uses default email service when none provided"""
+        with patch('authentication.email_services.BrevoEmailService.send_password_reset_email') as mock_send:
+            service = PasswordResetService() 
+            
+            service.process_reset_request('test@example.com')
+            
+            mock_send.assert_called_once()
+            args, kwargs = mock_send.call_args
+            self.assertEqual(args[0], 'test@example.com')
+    
+    def test_password_reset_service_with_brevo_email(self):
+        """Test PasswordResetService with Brevo email service"""
+        from authentication.email_services import BrevoEmailService
+        with patch('authentication.email_services.TransactionalEmailsApi') as mock_api:
+            mock_instance = MagicMock()
+            mock_api.return_value = mock_instance
+            
+            email_service = BrevoEmailService()
+            service = PasswordResetService(email_service=email_service)
+            
+            service.process_reset_request('test@example.com')
+            
+            mock_instance.send_transac_email.assert_called_once()
 
-    @patch('authentication.services.TransactionalEmailsApi')
-    @patch('authentication.services.ApiClient')
-    @patch('authentication.services.os.getenv')
-    @patch('builtins.print')
-    def test_send_brevo_email_api_exception(self, mock_print, mock_getenv, mock_api_client, mock_transactional_api):
-        """Test handling of API exception when sending email"""
-        mock_getenv.return_value = "mock-api-key"
-        mock_api_instance = mock_transactional_api.return_value
-        mock_api_instance.send_transac_email.side_effect = ApiException(reason="API Error")
+    def test_email_service_error_handling(self):
+        """Test error handling in different email services"""
         
-        self.service.send_brevo_email("https://example.com/reset", "user@example.com")
-        
-        mock_print.assert_any_call("Exception when calling TransactionalEmailsApi->send_transac_email: %s\n" % mock_api_instance.send_transac_email.side_effect)
-
-    @patch('authentication.services.TransactionalEmailsApi')
-    @patch('authentication.services.ApiClient')
-    @patch('authentication.services.os.getenv')
-    def test_send_brevo_email_missing_api_key(self, mock_getenv, mock_api_client, mock_transactional_api):
-        """Test behavior when API key is missing"""
-        mock_getenv.return_value = None
-        
-        self.service.send_brevo_email("https://example.com/reset", "user@example.com")
-        
-        mock_api_client.assert_called_once()
-        config = mock_api_client.call_args[0][0]
-        self.assertIsNone(config.api_key.get('api-key'))
-
-    @patch('authentication.services.PasswordResetService.send_brevo_email')
-    def test_process_reset_request_uses_brevo(self, mock_send_brevo):
-        """Test that process_reset_request uses send_brevo_email"""
-        mock_send_brevo.return_value = None
-        
-        self.service.process_reset_request('test@example.com')
-        
-        mock_send_brevo.assert_called_once()
-        args = mock_send_brevo.call_args[0]
-        self.assertTrue(len(args) >= 2) 
-        self.assertEqual(args[1], 'test@example.com')  
-
-    @patch('authentication.services.TransactionalEmailsApi')
-    @patch('authentication.services.ApiClient')
-    @patch('authentication.services.os.getenv')
-    def test_send_brevo_email_special_chars(self, mock_getenv, mock_api_client, mock_transactional_api):
-        """Test sending email with special characters in reset link"""
-        mock_getenv.return_value = "mock-api-key"
-        mock_api_instance = mock_transactional_api.return_value
-        
-        special_link = "https://example.com/reset?token=abc&id=123#section"
-        self.service.send_brevo_email(special_link, "user@example.com")
-        
-        send_email_call = mock_api_instance.send_transac_email.call_args[0][0]
-        self.assertEqual(send_email_call.params["reset_link"], special_link)
+        with patch('authentication.email_services.TransactionalEmailsApi') as mock_api:
+            mock_instance = MagicMock()
+            mock_api.return_value = mock_instance
+            mock_instance.send_transac_email.side_effect = ApiException(reason="API Error")
+            
+            brevo_service = BrevoEmailService()
+            
+            with self.assertRaises(ApiException):
+                brevo_service.send_password_reset_email("test@example.com", "https://reset.link")

--- a/authentication/throttling.py
+++ b/authentication/throttling.py
@@ -1,0 +1,10 @@
+from rest_framework.throttling import AnonRateThrottle
+
+class PasswordResetRateThrottle(AnonRateThrottle):
+    """
+    Throttle for password reset requests - limits by IP address.
+    """
+    scope = 'password_reset'
+    
+    def get_cache_key(self, request, view):
+        return self.get_ident(request)

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -7,6 +7,7 @@ from pt_backend.models import User
 
 from .serializers import SignupSerializer
 from .security import APIKeyAuthentication
+from .throttling import PasswordResetRateThrottle
 from authentication.registration.service import (
     RegistrationService,
     RegistrationError,
@@ -43,6 +44,7 @@ class SignupAPIView(APIView):
 class PasswordResetLinkRequestView(APIView):
     authentication_classes = [APIKeyAuthentication]
     permission_classes = []
+    throttle_classes = [PasswordResetRateThrottle]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/pantau_tular/settings.py
+++ b/pantau_tular/settings.py
@@ -67,6 +67,7 @@ MIDDLEWARE = [
 REST_FRAMEWORK = {
     "DEFAULT_THROTTLE_RATES": {
         "user": "10/min",   
+        "password_reset": "5/day",
     },
 }
 

--- a/pantau_tular/test_settings.py
+++ b/pantau_tular/test_settings.py
@@ -36,6 +36,14 @@ LOGGING = {
     'disable_existing_loggers': True,
 }
 
+# Disable throttling for tests
+REST_FRAMEWORK = {
+    "DEFAULT_THROTTLE_RATES": {
+        "user": None,
+        "password_reset": None,
+    },
+}
+
 # Disable migrations during tests
 class DisableMigrations:
     def __contains__(self, item):

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ typing_extensions==4.12.2
 tzdata==2025.1
 urllib3==2.3.0
 whitenoise==6.9.0
+sib-api-v3-sdk


### PR DESCRIPTION
## Overview 
This PR improves code security and integrates email delivery with Brevo's production ready email service. The email service implementation is also done using DIP so that the code is easier to maintain and does not require much modification if you want to change to another email provider 

## Features Added 
- Implementing custom throttling for password reset link requests with a rate of 5 times a day, throttling is done based on IP address
- Implementing dependency injection for email service delivery

## How to Test
- Add `BREVO_API_KEY` to your environment variables
- Send request to `http://localhost:8000/authentication/password-reset-request` with payload
```
{
    "email": "email1@gmail.com"
}
```
- System will send a response with following message
```
{
  "message": "Jika akunmu terdaftar, kami sudah mengirim link untuk mereset password akun Anda"
}
```
- Check your email inbox, if your email is registered in PantauTular database the message should be sent, also make sure to check your spam folder.

## Future Works
- Implement asynchronous email sending