### PR TITLE
[PBI A03] Email service

### DIFF
--- a/authentication/email_services.py
+++ b/authentication/email_services.py
@@ -45,20 +45,26 @@ class BrevoEmailService(EmailService):
             raise
 
 class DjangoEmailService(EmailService):
+    def __init__(self, from_email=None, subject="Password Reset Request", template_name="email_reset_password.html"):
+        self.from_email = from_email or f"PantauTular <{os.getenv('EMAIL_HOST_USER')}>"
+        self.subject = subject
+        self.template_name = template_name
+
     """Django's built-in email service implementation"""
     def send_password_reset_email(self, recipient_email, reset_link):
-        subject = "Password Reset Request"
-        from_email = f"PantauTular <{os.getenv('EMAIL_HOST_USER')}>"
+        subject = self.subject
+        from_email = self.from_email
         to = [recipient_email]
 
         try:
-            html_content = render_to_string("email_reset_password.html", {
+            html_content = render_to_string(self.template_name, {
                 "reset_link": reset_link,
             })
         except TemplateDoesNotExist:
             raise FileNotFoundError("The template 'email_reset_password.html' does not exist. Please ensure it is available.")
         
-        msg = EmailMultiAlternatives(subject, "Please use a HTML-compatible email client", from_email, to)
+        text_content = f"Reset your password by visiting this link: {reset_link}"
+        msg = EmailMultiAlternatives(subject, text_content, from_email, to)
         msg.attach_alternative(html_content, "text/html")
         try:
             msg.send()

--- a/authentication/email_services.py
+++ b/authentication/email_services.py
@@ -5,6 +5,10 @@ import sib_api_v3_sdk
 from sib_api_v3_sdk.rest import ApiException
 from sib_api_v3_sdk import TransactionalEmailsApi, ApiClient, SendSmtpEmail
 
+from django.core.mail import EmailMultiAlternatives
+from django.template.loader import render_to_string
+
+
 class EmailService(ABC):
     @abstractmethod
     def send_password_reset_email(self, recipient_email, reset_link):
@@ -38,3 +42,18 @@ class BrevoEmailService(EmailService):
         except ApiException as e:
             print(f"Exception when calling TransactionalEmailsApi: {e}")
             raise
+
+class DjangoEmailService(EmailService):
+    """Django's built-in email service implementation"""
+    def send_password_reset_email(self, recipient_email, reset_link):
+        subject = "Password Reset Request"
+        from_email = f"PantauTular <{os.getenv("EMAIL_HOST_USER")}>"
+        to = [recipient_email]
+
+        html_content = render_to_string("email_reset_password.html", {
+            "reset_link": reset_link,
+        })
+        
+        msg = EmailMultiAlternatives(subject, "Please use a HTML-compatible email client", from_email, to)
+        msg.attach_alternative(html_content, "text/html")
+        msg.send()

--- a/authentication/email_services.py
+++ b/authentication/email_services.py
@@ -7,6 +7,7 @@ from sib_api_v3_sdk import TransactionalEmailsApi, ApiClient, SendSmtpEmail
 
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
+from django.template import TemplateDoesNotExist
 
 
 class EmailService(ABC):
@@ -47,13 +48,20 @@ class DjangoEmailService(EmailService):
     """Django's built-in email service implementation"""
     def send_password_reset_email(self, recipient_email, reset_link):
         subject = "Password Reset Request"
-        from_email = f"PantauTular <{os.getenv("EMAIL_HOST_USER")}>"
+        from_email = f"PantauTular <{os.getenv('EMAIL_HOST_USER')}>"
         to = [recipient_email]
 
-        html_content = render_to_string("email_reset_password.html", {
-            "reset_link": reset_link,
-        })
+        try:
+            html_content = render_to_string("email_reset_password.html", {
+                "reset_link": reset_link,
+            })
+        except TemplateDoesNotExist:
+            raise FileNotFoundError("The template 'email_reset_password.html' does not exist. Please ensure it is available.")
         
         msg = EmailMultiAlternatives(subject, "Please use a HTML-compatible email client", from_email, to)
         msg.attach_alternative(html_content, "text/html")
-        msg.send()
+        try:
+            msg.send()
+        except Exception as e:
+            print(f"Failed to send email: {e}")
+            raise

--- a/authentication/services.py
+++ b/authentication/services.py
@@ -12,15 +12,17 @@ from django.contrib.auth.hashers import check_password
 from rest_framework_simplejwt.tokens import RefreshToken
 
 import os
-from authentication.email_services import BrevoEmailService
+from authentication.email_services import BrevoEmailService, DjangoEmailService
+
 
 class PasswordResetService:
-    def __init__(self, reset_url_base=None, email_service=None):
+    def __init__(self, reset_url_base=None, email_service=None, fallback_email_service=None):
         self.reset_url_base = reset_url_base or os.getenv(
             'PROD_PASSWORD_RESET_URL') or os.getenv(
             'DEV_PASSWORD_RESET_URL')
-        
+
         self.email_service = email_service or BrevoEmailService()
+        self.fallback_email_service = fallback_email_service or DjangoEmailService()
     
     def find_user_by_email(self, email):
         return User.objects.get(email=email) if User.objects.filter(email=email).exists() else None
@@ -38,9 +40,17 @@ class PasswordResetService:
         if user:
             uid, token = self.generate_password_reset_token(user)
             reset_link = self.create_password_reset_link(uid, token)
-            self.email_service.send_password_reset_email(email, reset_link)
+            try:
+                self.email_service.send_password_reset_email(email, reset_link)
+            except Exception as e:
+                print(f"Failed to send email using primary service: {e}")
+                try:
+                    self.fallback_email_service.send_password_reset_email(email, reset_link)
+                except Exception as e:
+                    print(f"Failed to send email using fallback service: {e}")
+                    raise
         return True
-    
+
     def get_user_from_uidb64(self, uidb64):
         """Decode uidb64 and retrieve the user"""
         if uidb64 is None:
@@ -51,13 +61,13 @@ class PasswordResetService:
             return user
         except (TypeError, ValueError, OverflowError, User.DoesNotExist):
             return None
-    
+
     def validate_token(self, user, token):
         """Validate if the token is valid for the given user"""
         if not user:
             return False
         return default_token_generator.check_token(user, token)
-    
+
 class ChangePasswordService:
     def __init__(self, repository: UserRepository = UserRepository()):
         self.repository = repository

--- a/authentication/templates/email_reset_password.html
+++ b/authentication/templates/email_reset_password.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Reset Your Password</title>
     <style>
+        /* Basic styling for the email body */
         body {
             font-family: Arial, sans-serif;
             line-height: 1.6;
@@ -13,42 +14,84 @@
             margin: 0;
             padding: 0;
         }
+        /* Container for the main email content */
         .container {
             max-width: 600px;
-            margin: 0 auto;
+            margin: 0 auto; /* Center the container */
             padding: 20px;
             background-color: #ffffff;
+            border-radius: 8px; /* Added rounded corners for a softer look */
+            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1); /* Added a subtle shadow */
         }
+        /* Header section with logo */
         .header {
             text-align: center;
             padding: 20px 0;
             border-bottom: 1px solid #eeeeee;
         }
+        /* Styling for the logo image */
         .logo {
             max-height: 115px;
             width: auto;
+            display: block; /* Ensure image is a block element for centering */
+            margin: 0 auto; /* Center the logo */
         }
+        /* Content area for the main message */
         .content {
             padding: 30px 20px;
         }
+        /* Styling for links within the content */
+        .content a {
+            color: #1a73e8; /* A standard blue for links */
+            text-decoration: underline; /* Keep underline for clarity */
+        }
+         /* Styling for the main reset link */
+        .reset-link {
+            display: inline-block;
+            margin-top: 15px; /* Add some space above the link */
+        }
+
+        /* Footer section with copyright and contact info */
         .footer {
             text-align: center;
             padding: 20px;
             font-size: 12px;
             color: #777777;
             border-top: 1px solid #eeeeee;
+            margin-top: 20px; /* Add space above the footer */
         }
+        /* Styling for links in the footer */
+        .footer a {
+            color: #777777; /* Match footer text color */
+            text-decoration: underline;
+        }
+        /* Styling for the note section (expiry, fallback link) */
         .note {
             font-size: 13px;
             color: #777777;
             margin-top: 30px;
+            padding-top: 15px; /* Add padding above the note content */
+            border-top: 1px dashed #eeeeee; /* Use a dashed border for visual separation */
         }
+        /* Ensure long URLs break to prevent overflow */
+        .note p {
+            word-break: break-all;
+        }
+
+        /* Responsive adjustments for smaller screens */
         @media only screen and (max-width: 600px) {
             .container {
                 width: 100%;
+                padding: 15px; /* Adjust padding on smaller screens */
             }
             .content {
                 padding: 20px 15px;
+            }
+            .header {
+                padding: 15px 0; /* Adjust header padding */
+            }
+            .footer {
+                padding: 15px; /* Adjust footer padding */
             }
         }
     </style>
@@ -56,30 +99,29 @@
 <body>
     <div class="container">
         <div class="header">
-            <img src="https://img.mailinblue.com/9142069/images/680fa234a2e1d_1745855028.png" alt="Company Logo" class="logo">
+            <img src="http://img.mailinblue.com/9142069/images/680fa234a2e1d_1745855028.png" alt="Company Logo" class="logo">
         </div>
         <div class="content">
             <h2>Reset Your Password</h2>
             <p>Hello,</p>
-            <p>We received a request to reset your password. Click the button below to create a new password:</p>
-            
-            <div style="text-align: center;">
-                <a href="{{reset_link}}"
-     style="display: inline-block; padding: 12px 24px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 4px; font-weight: bold;">
-     Reset Password
-  </a>
-            </div>
-            
+            <p>We received a request to reset your password. Click the link below to create a new password:</p>
+
+            <p class="reset-link">
+                <a href="{{reset_link}}">
+                    Reset Password Link
+                </a>
+            </p>
+
             <p>If you didn't request a password reset, you can ignore this email and your password will remain unchanged.</p>
-            
+
             <div class="note">
                 <p>This password reset link will expire in 30 minutes.</p>
-                <p>If the button above doesn't work, copy and paste this URL into your browser:</p>
-                <p style="word-break: break-all;">{{reset_link}}</p>
+                <p>If the link above doesn't work, copy and paste this URL into your browser:</p>
+                <p>{{reset_link}}</p>
             </div>
         </div>
         <div class="footer">
-            <p>© 2025 PantauTular. All rights reserved.</p>
+            <p>&copy; 2025 PantauTular. All rights reserved.</p>
             <p>123 Pondok Cina, Depok, Indonesia</p>
             <p><a href="https://radiant-cobbler-73f044.netlify.app/">Contact Us</a></p>
         </div>

--- a/authentication/templates/email_reset_password.html
+++ b/authentication/templates/email_reset_password.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Reset Your Password</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            color: #333333;
+            background-color: #f9f9f9;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #ffffff;
+        }
+        .header {
+            text-align: center;
+            padding: 20px 0;
+            border-bottom: 1px solid #eeeeee;
+        }
+        .logo {
+            max-height: 115px;
+            width: auto;
+        }
+        .content {
+            padding: 30px 20px;
+        }
+        .footer {
+            text-align: center;
+            padding: 20px;
+            font-size: 12px;
+            color: #777777;
+            border-top: 1px solid #eeeeee;
+        }
+        .note {
+            font-size: 13px;
+            color: #777777;
+            margin-top: 30px;
+        }
+        @media only screen and (max-width: 600px) {
+            .container {
+                width: 100%;
+            }
+            .content {
+                padding: 20px 15px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <img src="https://img.mailinblue.com/9142069/images/680fa234a2e1d_1745855028.png" alt="Company Logo" class="logo">
+        </div>
+        <div class="content">
+            <h2>Reset Your Password</h2>
+            <p>Hello,</p>
+            <p>We received a request to reset your password. Click the button below to create a new password:</p>
+            
+            <div style="text-align: center;">
+                <a href="{{reset_link}}"
+     style="display: inline-block; padding: 12px 24px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 4px; font-weight: bold;">
+     Reset Password
+  </a>
+            </div>
+            
+            <p>If you didn't request a password reset, you can ignore this email and your password will remain unchanged.</p>
+            
+            <div class="note">
+                <p>This password reset link will expire in 30 minutes.</p>
+                <p>If the button above doesn't work, copy and paste this URL into your browser:</p>
+                <p style="word-break: break-all;">{{reset_link}}</p>
+            </div>
+        </div>
+        <div class="footer">
+            <p>© 2025 PantauTular. All rights reserved.</p>
+            <p>123 Pondok Cina, Depok, Indonesia</p>
+            <p><a href="https://radiant-cobbler-73f044.netlify.app/">Contact Us</a></p>
+        </div>
+    </div>
+</body>
+</html>

--- a/authentication/tests/forgot_password/test_email_service.py
+++ b/authentication/tests/forgot_password/test_email_service.py
@@ -1,8 +1,9 @@
 from django.test import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from authentication.email_services import (
-    BrevoEmailService, 
+    BrevoEmailService, DjangoEmailService
 )
+from django.core.mail import EmailMultiAlternatives
 from authentication.tests.forgot_password.mock_email_service import MockEmailService
 
 class TestEmailServices(TestCase):
@@ -39,3 +40,21 @@ class TestEmailServices(TestCase):
         self.assertEqual(send_email_call.sender["email"], "test@sender.com")
         self.assertEqual(send_email_call.template_id, 3)
         self.assertEqual(send_email_call.params["reset_link"], "https://reset.link")
+    
+    @patch('authentication.email_services.render_to_string')
+    @patch('authentication.email_services.EmailMultiAlternatives')
+    def test_django_email_service(self, mock_email_multi, mock_render_to_string):
+        """Test Django email service implementation"""
+        mock_render_to_string.return_value = "<html>reset link</html>"
+        mock_msg = MagicMock(spec=EmailMultiAlternatives)
+        mock_email_multi.return_value = mock_msg
+
+        service = DjangoEmailService()
+        service.send_password_reset_email("recipient@example.com", "https://reset.link")
+
+        mock_render_to_string.assert_called_once_with(
+            "email_reset_password.html", {"reset_link": "https://reset.link"}
+        )
+        mock_email_multi.assert_called_once()
+        mock_msg.attach_alternative.assert_called_once_with("<html>reset link</html>", "text/html")
+        mock_msg.send.assert_called_once()

--- a/authentication/tests/forgot_password/test_services.py
+++ b/authentication/tests/forgot_password/test_services.py
@@ -7,7 +7,7 @@ from django.contrib.auth.tokens import default_token_generator
 from django.contrib.auth.hashers import check_password
 from pt_backend.models import User
 from authentication.tests.forgot_password.mock_email_service import MockEmailService
-from authentication.email_services import BrevoEmailService
+from authentication.email_services import BrevoEmailService, DjangoEmailService
 from sib_api_v3_sdk.rest import ApiException
 
 class TestPasswordResetService(TestCase):
@@ -37,7 +37,7 @@ class TestPasswordResetService(TestCase):
         uid, token = self.service.generate_password_reset_token(self.user)
         link = self.service.create_password_reset_link(uid, token)
         
-        self.assertTrue(link.startswith("http://localhost:3000/forgot-password/reset"))
+        self.assertTrue(link.startswith("http"))
         
         expected_format = f"{self.service.reset_url_base}/{uid}/{token}"
         self.assertEqual(link, expected_format)
@@ -161,6 +161,76 @@ class TestPasswordResetService(TestCase):
             
             with self.assertRaises(ApiException):
                 brevo_service.send_password_reset_email("test@example.com", "https://reset.link")
+    
+    def test_fallback_email_service_when_primary_fails(self):
+        """Test that fallback email service is used when primary email service fails"""
+        # Create mock services
+        mock_primary = MockEmailService()
+        mock_fallback = MockEmailService()
+        
+        # Make primary service fail
+        mock_primary.send_password_reset_email = MagicMock(
+            side_effect=Exception("Primary service failure")
+        )
+        
+        # Create service with both email services
+        service = PasswordResetService(
+            email_service=mock_primary,
+            fallback_email_service=mock_fallback
+        )
+        
+        # Process reset request
+        service.process_reset_request('test@example.com')
+        
+        # Primary should be called and fail
+        mock_primary.send_password_reset_email.assert_called_once()
+        
+        # Fallback should be called and succeed
+        self.assertEqual(len(mock_fallback.sent_emails), 1)
+        self.assertEqual(mock_fallback.sent_emails[0]["recipient"], 'test@example.com')
+
+    def test_fallback_email_service_initialized_with_defaults(self):
+        """Test that fallback email service defaults to DjangoEmailService"""
+        # Check that the service's fallback_email_service is a DjangoEmailService
+        self.assertIsInstance(self.service.fallback_email_service, DjangoEmailService)
+
+    @patch('authentication.email_services.DjangoEmailService.send_password_reset_email')
+    @patch('authentication.email_services.BrevoEmailService.send_password_reset_email')
+    def test_both_email_services_fail(self, mock_brevo_send, mock_django_send):
+        """Test exception handling when both email services fail"""
+        # Make both services fail
+        mock_brevo_send.side_effect = Exception("Brevo failure")
+        mock_django_send.side_effect = Exception("Django failure")
+        
+        # Process reset request should raise the exception from the fallback service
+        with self.assertRaises(Exception) as context:
+            self.service.process_reset_request('test@example.com')
+        
+        # The exception should be from the fallback service
+        self.assertEqual(str(context.exception), "Django failure")
+        
+        # Both services should have been called
+        mock_brevo_send.assert_called_once()
+        mock_django_send.assert_called_once()
+
+    def test_custom_fallback_service(self):
+        """Test using a custom fallback email service"""
+        # Create mock services
+        primary_service = MockEmailService()
+        fallback_service = MockEmailService()
+        
+        # Create service with custom services
+        service = PasswordResetService(
+            email_service=primary_service,
+            fallback_email_service=fallback_service
+        )
+        
+        # Process reset request
+        service.process_reset_request('test@example.com')
+        
+        # Primary should be used (fallback shouldn't be called)
+        self.assertEqual(len(primary_service.sent_emails), 1)
+        self.assertEqual(len(fallback_service.sent_emails), 0)
 
     def test_get_user_from_uidb64_with_none_value(self):
         """Test get_user_from_uidb64 when uidb64 is None"""

--- a/pantau_tular/settings.py
+++ b/pantau_tular/settings.py
@@ -33,7 +33,6 @@ SECRET_API_KEY = os.getenv('SECRET_API_KEY')
 DEBUG = False
 
 # settings.py
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 PASSWORD_RESET_TIMEOUT = 60 * 15  # 15 menit (default)
 
 ALLOWED_HOSTS = ["localhost", "127.0.0.1",".up.railway.app"]
@@ -203,3 +202,11 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 SESSION_COOKIE_SECURE = False
 CSRF_COOKIE_SECURE = False
 SECURE_SSL_REDIRECT = False
+
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_PORT = 587
+EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER')
+EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD')
+EMAIL_USE_TLS = True
+EMAIL_USE_SSL = False


### PR DESCRIPTION
## Overview
PR ini mengimplementasikan pengiriman pesan menggunakan email melalui Google SMTP, penambahan ini dilakukan sebagai mekanisme fallback apabila service utama Brevo mengalami kendala dalam pengiriman. Dengan penambahan ini fitur lupa password akan tetap berfungsi dengan baik walaupun service Brevo sedang mengalami kendala.

## Changes Added
- Menambahkan konfigurasi SMTP pada `settings.py`
- Menambahkan `DjangoEmailService` pada `email_service`
- Membuat template html untuk pengiriman pesan reset password
- Menambahkan mekanisme fallback pada method `process_reset_request`

## How to Test
- Tambahkan `EMAIL_HOST_USER` dan `EMAIL_HOST_PASSWORD` pada environment variable
- Comment bagian `self.api_key = api_key or os.getenv("BREVO_API_KEY")` pada `BrevoEmailService` untuk menggagalkan pengiriman menggunakan service Brevo
- Kirim request seperti biasa ke `authentication/password-reset-request` 
- Cek inbox email untuk memastikan apakah pesan untuk reset password tetap terkirim