### PR TITLE
[PBI D01] : duplicate case ID handling to statistical reports

### DIFF
--- a/pt_backend/statistics/reports/gender_grouping.py
+++ b/pt_backend/statistics/reports/gender_grouping.py
@@ -7,17 +7,27 @@ class GenderGroupingReport(ReportStrategy):
     def generate_report(self, filtered_cases=None):
         """Generate gender distribution report"""
         gender_counts = Counter()
+        counted_cases = set()
 
         if not filtered_cases:
             return {"male": 0, "female": 0}
 
         for case in filtered_cases:
-            if case and isinstance(case, dict):
-                gender = case.get("gender")
-                if isinstance(gender, str):  # Pastikan gender adalah string
-                    gender = gender.lower()
-                    if gender in ["male", "female"]:
-                        gender_counts[gender] += 1
+            if not case or not isinstance(case, dict):
+                continue
+                
+            case_id = case.get("id")
+            
+            if case_id in counted_cases:
+                continue
+                
+            counted_cases.add(case_id)
+            
+            gender = case.get("gender")
+            if isinstance(gender, str):
+                gender = gender.lower()
+                if gender in ["male", "female"]:
+                    gender_counts[gender] += 1
 
         return {
             "male": gender_counts.get("male", 0),

--- a/pt_backend/statistics/reports/severity_grouping.py
+++ b/pt_backend/statistics/reports/severity_grouping.py
@@ -7,10 +7,18 @@ class SeverityGroupingReport(ReportStrategy):
     def generate_report(self, filtered_cases = None):
         severity_counts = Counter()
         total_cases = 0
+        counted_cases = set()
         
         if filtered_cases:
             for case in filtered_cases:
+                case_id = case.get("id")
+
+                if case_id in counted_cases:
+                    continue
+
+                counted_cases.add(case_id)
                 total_cases += 1
+                
                 severity = case.get("severity")
                 if severity is not None:
                     severity_counts[severity] += 1

--- a/pt_backend/tests/statistics/test_gender_grouping.py
+++ b/pt_backend/tests/statistics/test_gender_grouping.py
@@ -77,3 +77,33 @@ class GenderGroupingReportTestCase(TestCase):
         cases = [{"id": i, "gender": "male" if i % 2 == 0 else "female"} for i in range(1, 10001)]
         result = self.report.generate_report(cases)
         self.assertEqual(result, {"male": 5000, "female": 5000})
+
+    def test_handle_duplicate_case_ids(self):
+        """
+        Test that the report correctly handles duplicate case IDs by only counting each unique ID once.
+        This simulates what happens when filtered_cases has duplicates due to multiple news items.
+        """
+        cases = [
+            {"id": 1, "gender": "male"},
+            {"id": 2, "gender": "female"},
+            {"id": 1, "gender": "male"},  # Duplicate ID
+            {"id": 3, "gender": "female"},
+            {"id": 2, "gender": "female"},  # Duplicate ID
+            {"id": 1, "gender": "male"},  # Duplicate ID
+        ]
+        result = self.report.generate_report(cases)
+        self.assertEqual(result, {"male": 1, "female": 2})
+        
+    def test_duplicate_ids_with_different_genders(self):
+        """
+        Test handling of an edge case where the same case ID appears multiple times 
+        with different gender values. Only the first occurrence should be counted.
+        """
+        cases = [
+            {"id": 1, "gender": "male"},
+            {"id": 2, "gender": "female"},
+            {"id": 1, "gender": "female"},  # Duplicate ID with different gender
+            {"id": 3, "gender": "male"}
+        ]
+        result = self.report.generate_report(cases)
+        self.assertEqual(result, {"male": 2, "female": 1})

--- a/pt_backend/tests/statistics/test_gender_grouping.py
+++ b/pt_backend/tests/statistics/test_gender_grouping.py
@@ -107,3 +107,20 @@ class GenderGroupingReportTestCase(TestCase):
         ]
         result = self.report.generate_report(cases)
         self.assertEqual(result, {"male": 2, "female": 1})
+
+    def test_invalid_case_formats(self):
+        """
+        Edge case: when some cases are not dictionaries or are None,
+        these should be skipped without errors.
+        """
+        cases = [
+            {"id": 1, "gender": "male"},     # Valid case
+            None,                           # None value - should be skipped
+            "not a dictionary",             # String - should be skipped
+            42,                             # Integer - should be skipped
+            ["list", "not dict"],           # List - should be skipped
+            {"id": 2, "gender": "female"},  # Valid case
+        ]
+        
+        result = self.report.generate_report(cases)
+        self.assertEqual(result, {"male": 1, "female": 1})

--- a/pt_backend/tests/statistics/test_severity_grouping.py
+++ b/pt_backend/tests/statistics/test_severity_grouping.py
@@ -26,9 +26,9 @@ class TestSeverityGroupingReport(unittest.TestCase):
         the report should correctly count the total and group by that severity.
         """
         cases = [
-            {"severity": "hospitalisasi"},
-            {"severity": "hospitalisasi"},
-            {"severity": "hospitalisasi"}
+            {"id": 1, "severity": "hospitalisasi"},
+            {"id": 2, "severity": "hospitalisasi"},
+            {"id": 3, "severity": "hospitalisasi"}
         ]
         self.dummy_filter_service.filter_cases.return_value = cases
         report = self.report_service.generate_report(cases)
@@ -42,13 +42,13 @@ class TestSeverityGroupingReport(unittest.TestCase):
         Note: Cases with None for severity are ignored.
         """
         cases = [
-            {"severity": "hospitalisasi"},
-            {"severity": "insiden"},
-            {"severity": "hospitalisasi"},
-            {"severity": "mortalitas"},
-            {"severity": "insiden"},
-            {"severity": "hospitalisasi"},
-            {"severity": None}  # This case should be ignored.
+            {"id": 1, "severity": "hospitalisasi"},
+            {"id": 2, "severity": "insiden"},
+            {"id": 3, "severity": "hospitalisasi"},
+            {"id": 4, "severity": "mortalitas"},
+            {"id": 5, "severity": "insiden"},
+            {"id": 6, "severity": "hospitalisasi"},
+            {"id": 7, "severity": None}  # This case should be ignored.
         ]
         self.dummy_filter_service.filter_cases.return_value = cases
         report = self.report_service.generate_report(cases)
@@ -57,4 +57,43 @@ class TestSeverityGroupingReport(unittest.TestCase):
             "hospitalisasi": 3,
             "insiden": 2,
             "mortalitas": 1
+        })
+
+    def test_handle_duplicate_case_ids(self):
+        """
+        Test that the report correctly handles duplicate case IDs by only counting each unique ID once.
+        This simulates what happens when filtered_cases has duplicates due to multiple news items.
+        """
+        cases = [
+            {"id": 1, "severity": "hospitalisasi"},
+            {"id": 2, "severity": "insiden"},
+            {"id": 1, "severity": "hospitalisasi"},  # Duplicate ID
+            {"id": 3, "severity": "mortalitas"},
+            {"id": 2, "severity": "insiden"},  # Duplicate ID
+            {"id": 1, "severity": "hospitalisasi"},  # Duplicate ID
+        ]
+        report = self.report_service.generate_report(cases)
+        self.assertEqual(report["total_cases"], 3)  # Only 3 unique cases
+        self.assertEqual(report["severity_counts"], {
+            "hospitalisasi": 1,
+            "insiden": 1,
+            "mortalitas": 1
+        })
+    
+    def test_duplicate_ids_with_different_severities(self):
+        """
+        Test handling of an edge case where the same case ID appears multiple times 
+        with different severity values. Only the first occurrence should be counted.
+        """
+        cases = [
+            {"id": 1, "severity": "hospitalisasi"},
+            {"id": 2, "severity": "insiden"},
+            {"id": 1, "severity": "mortalitas"},  # Duplicate ID with different severity
+            {"id": 3, "severity": "hospitalisasi"}
+        ]
+        report = self.report_service.generate_report(cases)
+        self.assertEqual(report["total_cases"], 3)
+        self.assertEqual(report["severity_counts"], {
+            "hospitalisasi": 2,
+            "insiden": 1
         })


### PR DESCRIPTION
# PR: Add duplicate case ID handling to statistical reports

## Summary
This PR addresses a potential data accuracy issue by implementing duplicate case ID handling in `GenderGroupingReport` and `SeverityGroupingReport`. The changes ensure that cases with multiple associated news items aren't counted more than once in statistical reports.

## Problem
The `CasesFilterService` can return cases with duplicate IDs when filtering by news-related attributes (like portal or publication date) because a single case may have multiple news items associated with it. This could lead to inaccurate statistics when these cases are processed by our report generators.

## Solution
- Added a `counted_cases` set to track which case IDs have already been processed
- Implemented logic to skip duplicate case IDs during report generation
- Added comprehensive unit tests to verify the deduplication behavior

## Implementation Details
Both report classes now check if a case ID has already been counted before processing it:
```python
case_id = case.get("id")
if case_id in counted_cases:
    continue
counted_cases.add(case_id)
```

## Testing
Added the following test cases:
- Basic duplicate ID handling (same case appearing multiple times with identical attributes)
- Edge case where duplicate IDs have different attributes (only the first occurrence is counted)

## Note
`SeverityDatesCountReport` intentionally does not implement this deduplication as it's designed to count news publications by date, where counting multiple news items for the same case is the intended behavior.