### PR TITLE
Severity filtering

### DIFF
--- a/pt_backend/tests/location_severity/test_severity_filtering_views.py
+++ b/pt_backend/tests/location_severity/test_severity_filtering_views.py
@@ -336,3 +336,102 @@ class SeverityFilteringStatsPostViewTests(TestCase):
             alert_levels=None,
             date_range=None
         )
+        
+    @patch.object(APIKeyAuthentication, 'authenticate', return_value=None)
+    @patch('pt_backend.views.CacheService')
+    @patch('pt_backend.views.SeverityFilteringService')
+    def test_post_with_cache_miss_and_hit(self, mock_service, mock_cache, mock_auth):
+        """Test cache miss followed by cache hit behavior"""
+        # Setup mocks
+        mock_service_instance = MagicMock(spec=SeverityFilteringService)
+        mock_service_instance.get_filter_stats.return_value = self.mock_results
+        mock_service.return_value = mock_service_instance
+        
+        mock_cache_instance = MagicMock()
+        # First call returns None (cache miss), second call returns results (cache hit)
+        mock_cache_instance.get.side_effect = [None, self.mock_results]
+        mock_cache.return_value = mock_cache_instance
+        
+        # First request - cache miss
+        response1 = self.client.post(
+            self.url,
+            data={"diseases": ["COVID-19"]},
+            format='json'
+        )
+        
+        # Second request - should be cache hit
+        response2 = self.client.post(
+            self.url, 
+            data={"diseases": ["COVID-19"]},
+            format='json'
+        )
+        
+        # Assertions
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        self.assertEqual(response2.status_code, status.HTTP_200_OK)
+        
+        # Service should be called only once (first request)
+        mock_service_instance.get_filter_stats.assert_called_once()
+        
+        # Cache should be queried twice and set once
+        self.assertEqual(mock_cache_instance.get.call_count, 2)
+        mock_cache_instance.set.assert_called_once()
+        
+    @patch.object(APIKeyAuthentication, 'authenticate', return_value=None)
+    @patch('pt_backend.views.SeverityFilteringService')
+    def test_post_with_none_and_empty_data(self, mock_service, mock_auth):
+        """Test handling of None and empty values in the request data"""
+        mock_service_instance = MagicMock(spec=SeverityFilteringService)
+        mock_service_instance.get_filter_stats.return_value = self.mock_results
+        mock_service.return_value = mock_service_instance
+        
+        # Test with None values in request
+        response = self.client.post(
+            self.url,
+            data={
+                "diseases": None, 
+                "locations": None,
+                "portals": None,
+                "level_of_alertness": None,
+                "start_date": None,
+                "end_date": None
+            },
+            format='json'
+        )
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_service_instance.get_filter_stats.assert_called_once_with(
+            diseases=None,
+            provinces=None,
+            cities=None,
+            news_portals=None,
+            alert_levels=None,
+            date_range=None
+        )
+        
+        # Reset mock for next test
+        mock_service_instance.get_filter_stats.reset_mock()
+        
+        # Test with empty lists/strings
+        response = self.client.post(
+            self.url,
+            data={
+                "diseases": [], 
+                "locations": {},
+                "portals": [],
+                "level_of_alertness": "",
+                "start_date": "",
+                "end_date": ""
+            },
+            format='json'
+        )
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_service_instance.get_filter_stats.assert_called_once_with(
+            diseases=None,  # Empty list should convert to None
+            provinces=None,
+            cities=None,
+            news_portals=None,
+            alert_levels=None,
+            date_range=None  # Empty strings should not be in date range
+        )

--- a/pt_backend/tests/test_views.py
+++ b/pt_backend/tests/test_views.py
@@ -13,7 +13,7 @@ import uuid
 import os
 from unittest.mock import patch, Mock
 import json
-from ..views import StatisticsView
+from ..views import StatisticsView, SeverityFilteringStatsView
 
 class CaseAPITest(TestCase):
     def setUp(self):
@@ -567,3 +567,399 @@ class WeightedSeverityAnalysisViewTest(TestCase):
         # Verify response
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.data, {"detail": "Invalid API Key"})
+
+class SeverityFilteringStatsViewTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.api_key = os.getenv("SECRET_API_KEY", "test-api-key")
+        self.client.credentials(HTTP_X_API_KEY=self.api_key)
+        self.url = reverse('severity-filtering-stats')
+        
+        # Mock the APIKeyAuthentication to always authenticate successfully
+        self.auth_patcher = patch('pt_backend.authentication.APIKeyAuthentication.authenticate')
+        self.mock_auth = self.auth_patcher.start()
+        self.mock_auth.return_value = (None, None)  # Return (user, auth) tuple
+        
+        # Mock SeverityFilteringService
+        self.service_patcher = patch('pt_backend.views.SeverityFilteringService')
+        self.mock_service = self.service_patcher.start()
+        self.mock_service_instance = Mock()
+        self.mock_service.return_value = self.mock_service_instance
+        
+        # Mock CacheService
+        self.cache_patcher = patch('pt_backend.views.CacheService')
+        self.mock_cache = self.cache_patcher.start()
+        self.mock_cache_instance = Mock()
+        self.mock_cache.return_value = self.mock_cache_instance
+        
+        # Sample mock results
+        self.mock_results = {
+            "disease_stats": [{"name": "COVID-19", "severity_counts": {"hospitalisasi": 10, "insiden": 5, "mortalitas": 2}, "total_cases": 17}],
+            "province_stats": [{"name": "DKI Jakarta", "severity_counts": {"hospitalisasi": 8, "insiden": 3, "mortalitas": 1}, "total_cases": 12}],
+            "city_stats": [{"name": "Jakarta", "severity_counts": {"hospitalisasi": 6, "insiden": 2, "mortalitas": 1}, "total_cases": 9}]
+        }
+        
+    def tearDown(self):
+        self.auth_patcher.stop()
+        self.service_patcher.stop()
+        self.cache_patcher.stop()
+        
+    def test_get_method_not_allowed(self):
+        """Test that GET method returns 405 Method Not Allowed"""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+    
+    def test_post_without_filters(self):
+        """Test POST without any filters"""
+        # Setup mock
+        self.mock_cache_instance.get.return_value = None
+        self.mock_service_instance.get_filter_stats.return_value = self.mock_results
+        
+        # Make request
+        response = self.client.post(self.url, data={}, format='json')
+        
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.mock_service_instance.get_filter_stats.assert_called_once_with(
+            diseases=None,
+            provinces=None,
+            cities=None,
+            news_portals=None,
+            alert_levels=None,
+            date_range=None
+        )
+        self.assertEqual(response.json(), self.mock_results)
+        # Verify caching occurred
+        self.mock_cache_instance.set.assert_called_once()
+    
+    def test_post_with_cached_results(self):
+        """Test POST with cached results available"""
+        # Setup cache hit
+        self.mock_cache_instance.get.return_value = self.mock_results
+        
+        # Make request
+        response = self.client.post(self.url, data={"diseases": ["COVID-19"]}, format='json')
+        
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), self.mock_results)
+        # Verify service was not called (used cache instead)
+        self.mock_service_instance.get_filter_stats.assert_not_called()
+    
+    def test_post_with_location_processing(self):
+        """Test location data processing in POST request"""
+        # Setup mocks
+        self.mock_cache_instance.get.return_value = None
+        self.mock_service_instance.get_filter_stats.return_value = self.mock_results
+        
+        # Mock Location.objects.filter
+        with patch('pt_backend.views.Location.objects.filter') as mock_loc_filter:
+            mock_exists = MagicMock()
+            mock_exists.exists.return_value = True
+            mock_loc_filter.return_value = mock_exists
+            
+            # Make request with location data
+            response = self.client.post(
+                self.url,
+                data={
+                    "locations": {
+                        "provinces": ["DKI Jakarta", "Jawa Barat"],
+                        "cities": ["Jakarta", "Bandung"]
+                    }
+                },
+                format='json'
+            )
+        
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        call_args = self.mock_service_instance.get_filter_stats.call_args[1]
+    
+        # Check each argument individually with flexible ordering where needed
+        self.assertEqual(call_args['diseases'], None)
+        self.assertIsNotNone(call_args['provinces'])
+        self.assertCountEqual(call_args['provinces'], ["DKI Jakarta", "Jawa Barat"])
+        self.assertIsNotNone(call_args['cities'])
+        self.assertCountEqual(call_args['cities'], ["Jakarta", "Bandung"])
+        self.assertEqual(call_args['news_portals'], None)
+        self.assertEqual(call_args['alert_levels'], None)
+        self.assertEqual(call_args['date_range'], None)
+        self.mock_service_instance.get_filter_stats.assert_called_once()
+        
+    def test_post_with_invalid_location(self):
+        """Test location data processing with invalid locations"""
+        # Setup mocks
+        self.mock_cache_instance.get.return_value = None
+        self.mock_service_instance.get_filter_stats.return_value = self.mock_results
+        
+        # Mock Location.objects.filter for invalid province
+        with patch('pt_backend.views.Location.objects.filter') as mock_loc_filter:
+            mock_exists = MagicMock()
+            mock_exists.exists.return_value = False  # Location does not exist
+            mock_loc_filter.return_value = mock_exists
+            
+            # Make request with invalid location data
+            response = self.client.post(
+                self.url,
+                data={
+                    "locations": {
+                        "provinces": ["Invalid Province"],
+                        "cities": ["Invalid City"]
+                    }
+                },
+                format='json'
+            )
+        
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.mock_service_instance.get_filter_stats.assert_called_once_with(
+            diseases=None,
+            provinces=None,  # Should be None since province doesn't exist
+            cities=None,     # Should be None since city doesn't exist
+            news_portals=None,
+            alert_levels=None,
+            date_range=None
+        )
+    
+    def test_post_with_date_range(self):
+        """Test POST with date range"""
+        # Setup mocks
+        self.mock_cache_instance.get.return_value = None
+        self.mock_service_instance.get_filter_stats.return_value = self.mock_results
+        
+        # Make request with date range
+        response = self.client.post(
+            self.url,
+            data={
+                "start_date": "2023-01-01",
+                "end_date": "2023-12-31"
+            },
+            format='json'
+        )
+        
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.mock_service_instance.get_filter_stats.assert_called_once_with(
+            diseases=None,
+            provinces=None,
+            cities=None,
+            news_portals=None,
+            alert_levels=None,
+            date_range=("2023-01-01", "2023-12-31")
+        )
+    
+    def test_post_with_portals_and_alertness(self):
+        """Test POST with news portals and alertness level"""
+        # Setup mocks
+        self.mock_cache_instance.get.return_value = None
+        self.mock_service_instance.get_filter_stats.return_value = self.mock_results
+        
+        # Make request with portals and alertness
+        response = self.client.post(
+            self.url,
+            data={
+                "portals": ["Kompas", "Detik"],
+                "level_of_alertness": "3"
+            },
+            format='json'
+        )
+        
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.mock_service_instance.get_filter_stats.assert_called_once_with(
+            diseases=None,
+            provinces=None,
+            cities=None,
+            news_portals=["Kompas", "Detik"],
+            alert_levels=3,
+            date_range=None
+        )
+    
+    def test_post_with_invalid_alertness_level(self):
+        """Test POST with invalid alertness level"""
+        # Setup mocks
+        self.mock_cache_instance.get.return_value = None
+        
+        # Make request with invalid alertness level
+        response = self.client.post(
+            self.url,
+            data={
+                "level_of_alertness": "not_a_number"
+            },
+            format='json'
+        )
+        
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", response.data)
+        self.assertIn("invalid literal for int()", response.data["error"])
+        # Service should not be called with invalid input
+        self.mock_service_instance.get_filter_stats.assert_not_called()
+    
+    def test_post_with_cache_generation_error(self):
+        """Test handling of cache key generation error"""
+        # Setup mocks
+        self.mock_cache_instance.get.return_value = None
+        self.mock_service_instance.get_filter_stats.return_value = self.mock_results
+        
+        # Force error in cache key generation
+        with patch('pt_backend.views.SeverityFilteringStatsView._generate_cache_key') as mock_gen_key:
+            mock_gen_key.side_effect = Exception("Cache key error")
+            
+            # Make request
+            response = self.client.post(self.url, data={"diseases": ["COVID-19"]}, format='json')
+        
+        # The view returns 400 Bad Request when cache generation fails, not 200 OK
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        
+        # Service should NOT be called when there's a cache key generation error
+        self.mock_service_instance.get_filter_stats.assert_not_called()
+        
+        # Check error message
+        self.assertIn("error", response.data)
+        self.assertIn("Cache key error", response.data["error"])
+
+    def test_post_with_service_exception(self):
+        """Test handling exception from service"""
+        # Setup mocks
+        self.mock_cache_instance.get.return_value = None
+        self.mock_service_instance.get_filter_stats.side_effect = Exception("Service error")
+        
+        # Make request
+        response = self.client.post(self.url, data={"diseases": ["COVID-19"]}, format='json')
+        
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", response.data)
+        self.assertIn("Service error", response.data["error"])
+    
+    def test_missing_api_key(self):
+        """Test request without API key"""
+        # Stop auth mock to test actual authentication
+        self.auth_patcher.stop()
+        
+        # Remove API key from request
+        self.client.credentials()
+        
+        # Make request
+        response = self.client.post(self.url, data={}, format='json')
+        
+        # Restart auth mock for other tests
+        self.auth_patcher = patch('pt_backend.authentication.APIKeyAuthentication.authenticate')
+        self.mock_auth = self.auth_patcher.start()
+        self.mock_auth.return_value = (None, None)
+        
+        # Assertion
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data, {"detail": "Invalid API Key"})
+    
+    def test_invalid_api_key(self):
+        """Test request with invalid API key"""
+        # Stop auth mock to test actual authentication
+        self.auth_patcher.stop()
+        
+        # Set invalid API key
+        self.client.credentials(HTTP_X_API_KEY="invalid-key")
+        
+        # Make request
+        response = self.client.post(self.url, data={}, format='json')
+        
+        # Restart auth mock for other tests
+        self.auth_patcher = patch('pt_backend.authentication.APIKeyAuthentication.authenticate')
+        self.mock_auth = self.auth_patcher.start()
+        self.mock_auth.return_value = (None, None)
+        
+        # Assertion
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data, {"detail": "Invalid API Key"})
+    
+    def test_generate_cache_key(self):
+        """Test the cache key generation function"""
+        view = SeverityFilteringStatsView()
+        view.cache_service = self.mock_cache_instance
+        
+        # Test with simple parameters
+        filter_params = {
+            'diseases': ['COVID-19'],
+            'provinces': ['DKI Jakarta'],
+            'cities': None,
+            'news_portals': None,
+            'alert_levels': 3,
+            'date_range': ('2023-01-01', '2023-12-31')
+        }
+        
+        # Mock cache get to return None and then execute
+        self.mock_cache_instance.get.return_value = None
+        
+        # Execute the function
+        view._generate_cache_key(filter_params)
+        
+        # Verify cache get was called
+        self.mock_cache_instance.get.assert_called_once()
+        
+        # Test with nested parameters that require conversion
+        filter_params = {
+            'diseases': ['COVID-19', 'Dengue'],
+            'provinces': {'DKI Jakarta', 'Jawa Barat'},  # Using a set
+            'cities': ['Jakarta', 'Bandung'],
+            'news_portals': ['Kompas'],
+            'alert_levels': 3,
+            'date_range': {'start': '2023-01-01', 'end': '2023-12-31'}  # Using a dict
+        }
+        
+        # Execute again with complex parameters
+        self.mock_cache_instance.get.reset_mock()
+        self.mock_cache_instance.get.return_value = None
+        view._generate_cache_key(filter_params)
+    
+    def test_generate_cache_key_with_cached_result(self):
+        """Test when cache key generation returns cached result"""
+        view = SeverityFilteringStatsView()
+        view.cache_service = self.mock_cache_instance
+        
+        # Setup mock to return cached result
+        self.mock_cache_instance.get.return_value = self.mock_results
+        
+        # Execute the function
+        result = view._generate_cache_key({'diseases': ['COVID-19']})
+        
+        # Verify result is the cached result
+        self.assertEqual(result, self.mock_results)
+        self.mock_cache_instance.get.assert_called_once()
+    
+    def test_process_location_data_with_empty_input(self):
+        """Test _process_location_data with empty input"""
+        view = SeverityFilteringStatsView()
+        
+        # Test with empty input
+        provinces, cities = view._process_location_data({})
+        self.assertIsNone(provinces)
+        self.assertIsNone(cities)
+        
+        # Test with None input
+        provinces, cities = view._process_location_data(None)
+        self.assertIsNone(provinces)
+        self.assertIsNone(cities)
+        
+    def test_process_location_data_with_location_list(self):
+        """Test _process_location_data with a list of locations"""
+        view = SeverityFilteringStatsView()
+        
+        # Mock Location.objects.filter
+        with patch('pt_backend.views.Location.objects.filter') as mock_loc_filter:
+            mock_exists = MagicMock()
+            mock_exists.exists.return_value = True
+            mock_loc_filter.return_value = mock_exists
+            
+            # Call the method with valid input
+            provinces, cities = view._process_location_data({
+                'provinces': ['DKI Jakarta', 'DKI Jakarta', 'Jawa Barat'],  # Duplicate intentional
+                'cities': ['Jakarta', 'Bandung']
+            })
+            
+        # Check that duplicates are removed and values are processed correctly
+        self.assertEqual(len(provinces), 2)
+        self.assertIn('DKI Jakarta', provinces)
+        self.assertIn('Jawa Barat', provinces)
+        self.assertEqual(len(cities), 2)
+        self.assertIn('Jakarta', cities)
+        self.assertIn('Bandung', cities)

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -361,18 +361,8 @@ class SeverityFilteringStatsView(APIView):
             filter_params = self._extract_filter_parameters(request.data)
             
             # Generate cache key based on filter parameters
-            hashable_items = []
-            for k, v in filter_params.items():
-                if isinstance(v, list):
-                    v = tuple(v)  # Convert lists to tuples (which are hashable)
-                elif isinstance(v, dict):
-                    # Convert nested dictionaries to tuples of tuples
-                    v = tuple((k2, tuple(v2) if isinstance(v2, list) else v2) 
-                                for k2, v2 in v.items())
-                hashable_items.append((k, v))
-
-            cache_key = f"stats_report_{hash(frozenset(hashable_items))}"
-
+            cache_key = self._generate_cache_key(filter_params)
+            
             # Check if results are in cache
             cached_results = self.cache_service.get(cache_key)
             if cached_results:
@@ -392,6 +382,27 @@ class SeverityFilteringStatsView(APIView):
                 {"error": f"Error processing filter request: {str(e)}"},
                 status=status.HTTP_400_BAD_REQUEST
             )
+    
+    def _generate_cache_key(self, filter_params):
+        try:
+            # Convert filter items to something hashable
+            hashable_items = []
+            for k, v in filter_params.items():
+                if isinstance(v, list):
+                    v = tuple(v)  # Convert lists to tuples (which are hashable)
+                elif isinstance(v, dict):
+                    # Convert nested dictionaries to tuples of tuples
+                    v = tuple((k2, tuple(v2) if isinstance(v2, list) else v2) 
+                                for k2, v2 in v.items())
+                hashable_items.append((k, v))
+
+            cache_key = f"stats_report_{hash(frozenset(hashable_items))}"
+            cached_result = self.cache_service.get(cache_key)
+            if cached_result:
+                return cached_result
+        except Exception as e:
+            # If caching fails, log it but continue without caching
+            print(f"Caching error in statistics: {str(e)}")
     
     def _extract_filter_parameters(self, data):
         """Extract and process filter parameters from request data"""

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -1,3 +1,4 @@
+import logging
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
@@ -30,7 +31,11 @@ from datetime import datetime
 from django.db import connections
 from django.db.utils import OperationalError
 
+logger = logging.getLogger(__name__)
+
 INTERNAL_SERVER_ERR_MSG = "An unexpected error occurred. Please try again later."
+CACHE_TIMEOUT = 600
+CACHE_KEY_PREFIX = "stats_report_"
 
 class AllCaseLocationsView(APIView):
     authentication_classes = [APIKeyAuthentication]
@@ -354,7 +359,7 @@ class SeverityFilteringStatsView(APIView):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.cache_service = CacheService()
-        self.cache_timeout = 600 # 10 min cache timeout
+        self.cache_timeout = CACHE_TIMEOUT
     
     def post(self, request):
         """Handle POST requests with JSON payload for filtering"""
@@ -397,14 +402,14 @@ class SeverityFilteringStatsView(APIView):
                     v = tuple((k2, tuple(v2) if isinstance(v2, list) else v2) 
                                 for k2, v2 in v.items())
                 hashable_items.append((k, v))
-
-            cache_key = f"stats_report_{hash(frozenset(hashable_items))}"
+            cache_key = f"{CACHE_KEY_PREFIX}{hash(frozenset(hashable_items))}"
             cached_result = self.cache_service.get(cache_key)
             if cached_result:
                 return cached_result
         except Exception as e:
-            # If caching fails, log it but continue without caching
-            print(f"Caching error in statistics: {str(e)}")
+            logger.error(f"Cache key generation error: {str(e)}")
+            return None
+
     
     def _extract_filter_parameters(self, data):
         """Extract and process filter parameters from request data"""

--- a/pt_backend/views.py
+++ b/pt_backend/views.py
@@ -349,15 +349,41 @@ class SeverityFilteringStatsView(APIView):
     authentication_classes = [APIKeyAuthentication]
     permission_classes = []
     
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.cache_service = CacheService()
+        self.cache_timeout = 600 # 10 min cache timeout
+    
     def post(self, request):
         """Handle POST requests with JSON payload for filtering"""
         try:
             # Extract and process filter parameters
             filter_params = self._extract_filter_parameters(request.data)
             
-            # Initialize service and get results
+            # Generate cache key based on filter parameters
+            hashable_items = []
+            for k, v in filter_params.items():
+                if isinstance(v, list):
+                    v = tuple(v)  # Convert lists to tuples (which are hashable)
+                elif isinstance(v, dict):
+                    # Convert nested dictionaries to tuples of tuples
+                    v = tuple((k2, tuple(v2) if isinstance(v2, list) else v2) 
+                                for k2, v2 in v.items())
+                hashable_items.append((k, v))
+
+            cache_key = f"stats_report_{hash(frozenset(hashable_items))}"
+
+            # Check if results are in cache
+            cached_results = self.cache_service.get(cache_key)
+            if cached_results:
+                return Response(cached_results, status=status.HTTP_200_OK)
+            
+            # Initialize service and get results if not in cache
             severity_filter = SeverityFilteringService()
             results = severity_filter.get_filter_stats(**filter_params)
+            
+            # Cache the results
+            self.cache_service.set(cache_key, results, timeout=self.cache_timeout)
             
             return Response(results, status=status.HTTP_200_OK)
         


### PR DESCRIPTION
This pull request introduces caching and enhanced testing for the `SeverityFilteringStatsView`. The changes aim to improve performance by caching results and ensuring robust handling of various input scenarios through comprehensive test cases.

### Caching Implementation in `SeverityFilteringStatsView`:

* Added a caching mechanism to store and retrieve filtering results based on a generated cache key. The cache timeout is set to 10 minutes. (`pt_backend/views.py`) [[1]](diffhunk://#diff-e7f2354a4178a8f031ed9a4e191cb0b56f7471449dc6b5882515ea19ce3ec25fR352-R377) [[2]](diffhunk://#diff-e7f2354a4178a8f031ed9a4e191cb0b56f7471449dc6b5882515ea19ce3ec25fR386-R406)
* Implemented the `_generate_cache_key` method to create unique, hashable keys from filter parameters for caching purposes. (`pt_backend/views.py`)

### Test Enhancements:

* Added new test cases in `SeverityFilteringStatsViewTest` to cover scenarios such as cache hits/misses, invalid inputs, location processing, and service exceptions. (`pt_backend/tests/test_views.py`)
* Introduced tests for the `_generate_cache_key` and `_process_location_data` methods to ensure correct behavior with various input formats. (`pt_backend/tests/test_views.py`)
* Added test cases in `test_severity_filtering_views.py` to validate cache behavior and handling of `None` or empty data in POST requests. (`pt_backend/tests/location_severity/test_severity_filtering_views.py`)

### Code Refactoring:

* Updated imports in `test_views.py` to include `SeverityFilteringStatsView`. (`pt_backend/tests/test_views.py`)

These changes collectively enhance the performance and robustness of the `SeverityFilteringStatsView` while ensuring high test coverage for various edge cases.